### PR TITLE
Renaming URLs to correct repo name

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
 
 <body class="error no-js">
   <script type="text/javascript">
-    window.location = "http://www.devonfw.com/?p=devon-ide";        
+    window.location = "http://www.devonfw.com/?p=ide";        
   </script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
 <body>
   <script type="text/javascript">
-    window.location = "http://www.devonfw.com/?p=devon-ide";        
+    window.location = "http://www.devonfw.com/?p=ide";        
   </script>
 </body>
 

--- a/oomph/.project
+++ b/oomph/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>devon-ide-oomph</name>
+	<name>ide-oomph</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/oomph/index/org.eclipse.setup
+++ b/oomph/index/org.eclipse.setup
@@ -39,15 +39,15 @@
   <productCatalog
       href="user-ext:/user.products.setup?class='http://www.eclipse.org/oomph/setup/1.0%23//ProductCatalog',name='user.products',label='%3CUser%20Products%3E',description='A%20container%20catalog%20for%20local%20user-defined%20products'#/"/>
   <productCatalog
-      href="http://devonfw.github.io/devon-ide/oomph/products/catalog_devonfw.setup#/"/>
+      href="http://devonfw.github.io/ide/oomph/products/catalog_devonfw.setup#/"/>
   <productCatalog
       href="http://oasp.github.io/oasp4j-ide/oomph/products/catalog_OASP.setup#/"/>
   <productCatalog
       href="redirectable.products.setup#/"/>
   <projectCatalog
-      href="http://devonfw.github.io/devon-ide/oomph/projects/catalog_devonfw.setup#/"/>
+      href="http://devonfw.github.io/ide/oomph/projects/catalog_devonfw.setup#/"/>
   <projectCatalog
-      href="http://devonfw.github.io/devon-ide/oomph/projects/catalog_devonfwjs.setup#/"/>
+      href="http://devonfw.github.io/ide/oomph/projects/catalog_devonfwjs.setup#/"/>
   <projectCatalog
       href="http://oasp.github.io/oasp4j-ide/oomph/projects/catalog_oasp.setup#/"/>
   <projectCatalog

--- a/oomph/products/DevonIde.setup
+++ b/oomph/products/DevonIde.setup
@@ -12,7 +12,7 @@
     xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
     xsi:schemaLocation="http://maybeec.github.io/oomph-task-unzip/1.0 https://raw.githubusercontent.com/maybeec/oomph-task-unzip/master/task-unzip-updatesite/model/Oomph-task-unzip.ecore http://maybeec.github.io/oomph-task-cli/1.0 https://raw.githubusercontent.com/maybeec/oomph-task-cli/master/task-cli-updatesite/model/Oomph-cli-task-1.0.ecore http://maybeec.github.io/task-fsrename/1.0 https://raw.githubusercontent.com/maybeec/oomph-task-fsrename/master/task-fsrename-updatesite/model/Oomph-task-fsrename.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore"
     name="devon.ide"
-    label="devon-ide">
+    label="ide">
   <annotation
       source="http://www.eclipse.org/oomph/setup/BrandingInfo">
     <detail
@@ -590,7 +590,7 @@
         xsi:type="setup:EclipseIniTask"
         excludedTriggers="STARTUP MANUAL"
         option="-Doomph.redirection.index.redirection="
-        value="index:/org.eclipse.setup->http://devonfw.github.io/devon-ide/oomph/index/org.eclipse.setup"
+        value="index:/org.eclipse.setup->http://devonfw.github.io/ide/oomph/index/org.eclipse.setup"
         vm="true">
       <description></description>
     </setupTask>

--- a/oomph/products/catalog_devonfw.setup
+++ b/oomph/products/catalog_devonfw.setup
@@ -46,7 +46,7 @@
     <repository
         url="${oomph.update.url}"/>
   </setupTask>
-  <product href="http://devonfw.github.io/devon-ide/oomph/products/DevonIde.setup#/"/>
+  <product href="http://devonfw.github.io/ide/oomph/products/DevonIde.setup#/"/>
   <product href="http://devonfw.github.io/tools-cobigen/oomph/products/CobiGenDevelopmentIDE.setup#/"/>
   <product href="http://devonfw.github.io/tools-cobigen/oomph/products/CobiGenDevelopmentResearchIDE.setup#/"/>
   <description>This product catalog provides IDEs from the devonfw project</description>

--- a/oomph/products/changelog.adoc
+++ b/oomph/products/changelog.adoc
@@ -1,4 +1,4 @@
-= Change log for devon-ide oomph setup
+= Change log for ide oomph setup
 
 == Versions
 

--- a/oomph/projects/DevonIde.setup
+++ b/oomph/projects/DevonIde.setup
@@ -8,25 +8,25 @@
     xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
     xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://de-mucevolve02/oomph/tasks/models/Git.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore"
     name="devon.ide"
-    label="devon-ide">
+    label="ide">
   <setupTask
       xsi:type="git:GitCloneTask"
       id="git.clone.devon.ide"
       location="${workspace.location/${scope.project.label}}"
       remoteURI="${github.remote.uri}"
       pushURI="${github.remote.uri}">
-    <description>Clones the devon-ide  repository from Github</description>
+    <description>Clones the ide  repository from Github</description>
   </setupTask>
   <setupTask
       xsi:type="setup:VariableTask"
       name="github.remote.uri"
       storageURI="scope://Workspace"
-      label="devon-ide Remote URI">
+      label="ide Remote URI">
     <choice
-        value="https://github.com/${github.fork.name}/devon-ide.git"
+        value="https://github.com/${github.fork.name}/ide.git"
         label="HTTPS"/>
     <choice
-        value="ssh://git@github.com/${github.fork.name}/devon-ide.git"
+        value="ssh://git@github.com/${github.fork.name}/ide.git"
         label="SSH"/>
   </setupTask>
   <setupTask
@@ -34,7 +34,7 @@
       name="github.fork.name"
       defaultValue="devonfw"
       storageURI="scope://Workspace"
-      label="devon-ide fork"/>
+      label="ide fork"/>
   <setupTask
       xsi:type="maven:MavenImportTask">
     <sourceLocator
@@ -44,6 +44,6 @@
       label="Master"/>
   <logicalProjectContainer
       xsi:type="setup:ProjectCatalog"
-      href="http://devonfw.github.io/devon-ide/oomph/projects/catalog_devonfw.setup#/"/>
+      href="http://devonfw.github.io/ide/oomph/projects/catalog_devonfw.setup#/"/>
   <description>tool to automate setup and update of development environment</description>
 </setup:Project>

--- a/oomph/projects/catalog_devonfw.setup
+++ b/oomph/projects/catalog_devonfw.setup
@@ -65,7 +65,7 @@
     <description>${workspace.location}</description>
   </setupTask>
   <project href="http://devonfw.github.io/devcon/oomph/projects/Devcon.setup#/"/>
-  <project href="http://devonfw.github.io/devon-ide/oomph/projects/DevonIde.setup#/"/>
+  <project href="http://devonfw.github.io/ide/oomph/projects/DevonIde.setup#/"/>
   <project href="http://devonfw.github.io/devon/oomph/projects/Devon.setup#/"/>
   <project href="http://devonfw.github.io/devonfw-locale/oomph/projects/DevonfwLocale.setup#/"/>
   <project href="http://devonfw.github.io/module-owasp-appsensor/oomph/projects/ModuleOwaspAppsensor.setup#/"/>


### PR DESCRIPTION
This repository has been renamed from `devon-ide` to `ide`. This has broken our CobiGen Oomph installer as the URLs are not correct.

This PR fixes this issue.