### PR TITLE
Eclipse with JDK out of the box

### DIFF
--- a/scripts/src/main/resources/scripts/command/eclipse
+++ b/scripts/src/main/resources/scripts/command/eclipse
@@ -21,10 +21,7 @@ function doInstallEclipsePlugin() {
 }
 
 function doSetup() {
-  if [ -n "${1}" ]
-  then
-    doDevonCommand java -q setup
-  fi
+  doDevonCommand java -q setup
   if [ -n "${1}" ] || [ ! -d "${ECLIPSE_HOME}" ]
   then
     #mirror="https://mirror.math.princeton.edu"


### PR DESCRIPTION
This PR fixes issue #265. It forces the installation of a JDK prior to installing Eclipse.

I have tested it on my local machine and now everything is working fine.