### PR TITLE
Updated Jenkins add command syntax in the documentation

### DIFF
--- a/documentation/jenkins.asciidoc
+++ b/documentation/jenkins.asciidoc
@@ -11,5 +11,5 @@ The `jenkins` commandlet allows to install, configure, and launch https://jenkin
 |`setup`         |Setup Jenkins (install and verify)
 |`start`         |Start your local Jenkins server
 |`stop`          |Stop your local Jenkins server
-|`add-ci`        |Add current project as CI job to your local Jenkins
+|`add`           |Add current project as CI job to your local Jenkins
 |=======================


### PR DESCRIPTION
The command `add-ci` doesn't exist anymore, it has been renamed to `add`.