### PR TITLE
Solved problems with cicdgen & devon4node installation

### DIFF
--- a/scripts/src/main/resources/scripts/command/cicdgen
+++ b/scripts/src/main/resources/scripts/command/cicdgen
@@ -4,7 +4,7 @@ source "$(dirname "${0}")"/../functions
 
 # $1: optional setup
 function doSetup() {
-  if command -v cicdgen &> /dev/null || [ "${1}" != "update" ]
+  if command -v cicdgen &> /dev/null && [ "${1}" != "update" ]
   then
     if [ "${1}" = "setup" ]
     then

--- a/scripts/src/main/resources/scripts/command/node
+++ b/scripts/src/main/resources/scripts/command/node
@@ -33,15 +33,9 @@ function doSetup() {
 
 function doSetupDevon4node() {
   if ! command -v devon4node &> /dev/null
-  then  
-    doDevonCommand npm -q setup
-    local npm_command="${DEVON_IDE_HOME}/software/node/npm"
-    if [ ! -x "${npm_command}" ]
-    then
-      npm_command="${DEVON_IDE_HOME}/software/node/bin/npm"
-    fi
+  then
     doDevonCommand yarn -q setup
-    doRunCommand "'${npm_command}' install -g @devon4node/cli@latest" "install devon4node"
+    doDevonCommand npm install -g @devon4node/cli@latest
   fi
 }
 

--- a/scripts/src/main/resources/scripts/command/node
+++ b/scripts/src/main/resources/scripts/command/node
@@ -34,8 +34,14 @@ function doSetup() {
 function doSetupDevon4node() {
   if ! command -v devon4node &> /dev/null
   then  
+    doDevonCommand npm -q setup
+    local npm_command="${DEVON_IDE_HOME}/software/node/npm"
+    if [ ! -x "${npm_command}" ]
+    then
+      npm_command="${DEVON_IDE_HOME}/software/node/bin/npm"
+    fi
     doDevonCommand yarn -q setup
-    doRunCommand "npm install -g @devon4node/cli@latest" "install devon4node"
+    doRunCommand "'${npm_command}' install -g @devon4node/cli@latest" "install devon4node"
   fi
 }
 


### PR DESCRIPTION
Fixed a bad conditional in the cicdgen installation.

Also, in order to be sure that the devon4node installation is using the npm inside the IDE, I added the lines to install & use npm that other commands are already using.