### PR TITLE
Fix typos inside documentation.

### DIFF
--- a/documentation/conf.asciidoc
+++ b/documentation/conf.asciidoc
@@ -23,7 +23,7 @@ This folder contains configurations for your IDE:
 The `.m2` folder is used for configurations of link:mvn.asciidoc[maven]. It contains the local `repository` folder used as cache for artifacts downloaded and installed by maven (see also https://maven.apache.org/guides/introduction/introduction-to-repositories.html[maven repositories]).
 Further there are two configuration files for maven:
 
-* https://maven.apache.org/settings.html[settings.xml] initialized from a template from your `devonfw-ide` xref:settings[]. You may customize this to your needs (configuring HTTP proxies, credentails, or other user-specific settings).
+* https://maven.apache.org/settings.html[settings.xml] initialized from a template from your `devonfw-ide` xref:settings[]. You may customize this to your needs (configuring HTTP proxies, credentials, or other user-specific settings).
 * https://maven.apache.org/guides/mini/guide-encryption.html[settings-security.xml] is auto-generated for you by `devonfw-ide` with a random password. This should make it easier for `devonfw-ide` users to use https://maven.apache.org/guides/mini/guide-encryption.html[password encryption] and never add passwords in plain text for better security.
 
 Finally there is a file `variables` for the user-specific link:configuration.asciidoc[configuration] of `devonfw-ide`.

--- a/documentation/configurator.asciidoc
+++ b/documentation/configurator.asciidoc
@@ -3,7 +3,7 @@ toc::[]
 
 = Configurator
 
-The `devonfw-ide` maintains and includes a tool called https://github.com/devonfw/ide/tree/master/configurator[devonfw-ide-configurator]. This allows to synchronize and manage complex configurations. Initially it was written for Eclipse that stores its information in a `.metadata` folder of your workspace. Unfortunately it contains different file-formats (including XML as String value inside properties files), temporary data as well as important configurations with sometimes mixtures of project specific, developer specific, and UI specific settings. To make it short it is a mess. Instead of bashing on Eclipse we want to make this IDE more usable and created a way to manage important parts of such configuration strcutures.
+The `devonfw-ide` maintains and includes a tool called https://github.com/devonfw/ide/tree/master/configurator[devonfw-ide-configurator]. This allows to synchronize and manage complex configurations. Initially it was written for Eclipse that stores its information in a `.metadata` folder of your workspace. Unfortunately it contains different file-formats (including XML as String value inside properties files), temporary data as well as important configurations with sometimes mixtures of project specific, developer specific, and UI specific settings. To make it short it is a mess. Instead of bashing on Eclipse we want to make this IDE more usable and created a way to manage important parts of such configuration structures.
 
 == How to use
 The easiest way is that you do not care. When you launch the IDE of your choice (e.g. via `devon eclipse`, `devon vscode` or by running `eclipse-main` script), this will happen automatically.
@@ -39,6 +39,6 @@ Many fundamental settings for Eclipse can be found in the sub-folder `https://gi
 * exit your IDE and wait till it is shutdown
 * run `ws-reverse` command for your IDE (e.g. `devon eclipse ws-reverse`) - ensure you do this in the same workspace (without intermediate `cd` commands).
 * review the changes to your link:settings.asciidoc[settings] (git diff)
-* if all looks as expected commit these changes and push them - consider using a feature branch and ask a colleguage to test these changes before you apply this to the main branch.
+* if all looks as expected commit these changes and push them - consider using a feature branch and ask a colleague to test these changes before you apply this to the main branch.
 * otherwise in case you modified an currently unmanaged setting you can try `ws-reverse-add` instead of `ws-reverse` and check the diff again. Be sure not to add undesired settings that should not be managed.
 * in case your changes are in an entirely new configuration file that is currently not managed (in 3.) you need to figure out this file manually and add it to the according location in 3.

--- a/documentation/eclipse.asciidoc
+++ b/documentation/eclipse.asciidoc
@@ -41,7 +41,7 @@ too many plugins that may waste resources but are not used by every developer yo
 * https://m-m-m.github.io/eclipse-templatevariables/latest[templatevariables] (for advanced JDT templates)
 * https://www.genuitec.com/updates/devstyle/ci/[devstyle]
 
-The link-titles are the IDs accepted by `devon eclipse add-plugin «id»`. Otherwise the full featureID has to be specified together with the URL of the update site. However this is intendet for project specific configuration. Here is an example how a project can configure the plugins in his `devon.properties` inside the link:settings.asciidoc[settings]:
+The link-titles are the IDs accepted by `devon eclipse add-plugin «id»`. Otherwise the full featureID has to be specified together with the URL of the update site. However this is intended for project specific configuration. Here is an example how a project can configure the plugins in its `devon.properties` inside the link:settings.asciidoc[settings]:
 ```
 ECLIPSE_PLUGINS=("AnyEditTools.feature.group" "http://andrei.gmxhome.de/eclipse/" "com.ess.regexutil.feature.group" "http://regex-util.sourceforge.net/update/")
 ```

--- a/documentation/features.asciidoc
+++ b/documentation/features.asciidoc
@@ -52,7 +52,7 @@ We support the following build-systems:
 
 However, also other IDEs, platforms, or tools can be easily integrated as link:cli.asciidoc#commandlet[commandlet]. 
 
-== Motiviation
+== Motivation
 
 `TL;DR`? Lets talk to developers in the proper language. Here are examples with `devonfw-ide`:
 

--- a/documentation/ide.asciidoc
+++ b/documentation/ide.asciidoc
@@ -10,7 +10,7 @@ You need to supply additional arguments as `devon ide «args»`. These are expla
 [options="header"]
 |=======================
 |*Argument(s)*                   |*Meaning*
-|`setup [«SETTINGS_URL»]`        |setup devonfw-ide (cloing the settings from the given URL)
+|`setup [«SETTINGS_URL»]`        |setup devonfw-ide (cloning the settings from the given URL)
 |`update [«package»]`            |update devonfw-ide
 |`update scripts [to «version»]` |update devonfw-ide
 |`uninstall`                     |uninstall devonfw-ide (if you want remote it entirely from your system)
@@ -28,13 +28,13 @@ Run `devon ide setup` to initially setup your `devonfw-ide`. It is recommended t
 
 == update
 Run `devon ide update` to update your `devonfw-ide`. This will check for updates and link:setup.asciidoc#install[install] them automatically.
-The optinal extrag argument (`«package»`) behaves as following:
+The optinal extra argument (`«package»`) behaves as following:
 
 * `scripts`: check if a new version of `devonfw-ide-scripts` is available. If so it will be downloaded and installed. As Windows is using file-locks, it is tricky to update a script while it is executed. Therefore, we update the `scripts` folder as an async background task and have to abort further processing at this point on windows as a workaround.
 * `settings`: update the link:settings.asciidoc[settings] (`git pull`).
 * `software`: update the link:software.asciidoc[software] (e.g. if versions have changed via `scripts` or `settings` update).
 * `all`: do all the above sequentially. 
-* none: `settings` and `software` is updated by default if no extra argument is given. This is the regular usage for project developers. Only perform an update of `scripts` when you are requested to do so by your technical lead. Espcially bigger projects need to test updates before rolling them out to the entire team. If developers would always update to the latest release of the `scripts` which is released globally, some project functionality might break causing problems and extra efforts in the teams.
+* none: `settings` and `software` is updated by default if no extra argument is given. This is the regular usage for project developers. Only perform an update of `scripts` when you are requested to do so by your technical lead. Especially bigger projects need to test updates before rolling them out to the entire team. If developers would always update to the latest release of the `scripts` which is released globally, some project functionality might break causing problems and extra efforts in the teams.
 
 In order to update to a specific version of `scripts` an explicit version can be specified after the additional `to` argument:
 ```

--- a/documentation/scripts.asciidoc
+++ b/documentation/scripts.asciidoc
@@ -36,7 +36,7 @@ This directory is the heart of the `devonfw-ide` and contains the required link:
 The https://github.com/devonfw/ide/tree/master/scripts/src/main/resources/scripts/command[command] folder contains the link:cli.asciidoc#commandlets[commandlets].
 The https://github.com/devonfw/ide/tree/master/scripts/src/main/resources/scripts/devon[devon] script is the key link:cli.asciidoc[command line interface] for `devonfw-ide`.
 For windows there is also https://github.com/devonfw/ide/tree/master/scripts/src/main/resources/scripts/devon.bat[devon.bat] to be used in CMD or PowerShell.
-As the `devon` link:cli.asciidoc[CLI] can be used as global command on your computer from any directory and gets link:setup.asciidoc#install[installed] centrally it aims to be stable, minimal, and leightweight.
+As the `devon` link:cli.asciidoc[CLI] can be used as global command on your computer from any directory and gets link:setup.asciidoc#install[installed] centrally it aims to be stable, minimal, and lightweight.
 The key logic to setup the environment variables is therefore in a separate script https://github.com/devonfw/ide/tree/master/scripts/src/main/resources/scripts/environment-project[environment-project] and its Windows variant https://github.com/devonfw/ide/tree/master/scripts/src/main/resources/scripts/environment-project.bat[environment-project.bat] inside this `scripts` folder.
 The file https://github.com/devonfw/ide/tree/master/scripts/src/main/resources/scripts/functions[functions] contains a collection of reusable bash functions.
 These are sourced and used by the link:cli.asciidoc#commandlets[commandlets].

--- a/documentation/settings.asciidoc
+++ b/documentation/settings.asciidoc
@@ -5,7 +5,7 @@ toc::[]
 
 The `devonfw-ide` requires `settings` with configuration templates for the arbitrary tools.
 
-To get an initial set of these settings we provide the https://github.com/devonfw/ide-settings[devonfw-ide-settings] as an initial package. These are also released so you can download the lastest stable version at http://search.maven.org/#search|ga|1|a%3A%22devonfw-ide-settings%22[maven central].
+To get an initial set of these settings we provide the https://github.com/devonfw/ide-settings[devonfw-ide-settings] as an initial package. These are also released so you can download the latest stable version at http://search.maven.org/#search|ga|1|a%3A%22devonfw-ide-settings%22[maven central].
 
 To test `devonfw-ide` or for small projects you can also use these the latest default settings.
 However, for collaborative projects we strongly encourage you to distribute and maintain the settings via a dedicated and project specific `git` repository (or any other version-control-system). This gives you the freedom to control and manage the tools with their versions and configurations during the project lifecycle.

--- a/documentation/settings.asciidoc
+++ b/documentation/settings.asciidoc
@@ -5,11 +5,11 @@ toc::[]
 
 The `devonfw-ide` requires `settings` with configuration templates for the arbitrary tools.
 
-To get an initial set of these settings we provide the https://github.com/devonfw/ide-settings[devonfw-ide-settings] as an initial package. These are also released so you can download a the lastes stable version from http://search.maven.org/#search|ga|1|a%3A%22devonfw-ide-settings%22[maven central].
+To get an initial set of these settings we provide the https://github.com/devonfw/ide-settings[devonfw-ide-settings] as an initial package. These are also released so you can download the lastest stable version at http://search.maven.org/#search|ga|1|a%3A%22devonfw-ide-settings%22[maven central].
 
 To test `devonfw-ide` or for small projects you can also use these the latest default settings.
 However, for collaborative projects we strongly encourage you to distribute and maintain the settings via a dedicated and project specific `git` repository (or any other version-control-system). This gives you the freedom to control and manage the tools with their versions and configurations during the project lifecycle.
-Therefore as technical lead creates a `settings` git repository for the project. He creates a "fork" https://github.com/devonfw/ide-settings[devonfw-ide-settings] by adding it as "upstream" origin and pulls from there finally pusing it to the project `settings` git. This also allows to later merge changes from the official https://github.com/devonfw/ide-settings[devonfw-ide-settings] back into the project specific `settings` "fork".
+Therefore a technical lead creates a `settings` git repository for the project. He creates a "fork" https://github.com/devonfw/ide-settings[devonfw-ide-settings] by adding it as "upstream" origin and pulls from there finally pushing it to the project `settings` git. This also allows to later merge changes from the official https://github.com/devonfw/ide-settings[devonfw-ide-settings] back into the project specific `settings` "fork".
 
 == Structure
 The settings folder (see `link:variables.asciidoc[SETTINGS_PATH]`) has to following file structure:
@@ -57,6 +57,6 @@ Different tools and configuration files require a different handling:
 * For tools with complex configuration structures like link:eclipse.asciidoc[eclipse], link:intellij..asciidoc[intellij], or link:vscode.asciidoc[vscode] we provide a smart mechanism via our link:configurator.asciidoc[configurator].
 
 == Customize Settings
-You can easily customize these settings for the requirements of your project. We suggest that one team member is repsonsible to ensure that everything stays consistent and works.
+You can easily customize these settings for the requirements of your project. We suggest that one team member is responsible to ensure that everything stays consistent and works.
 
 You may also create new sub-folders in `settings` and put individual things according to your needs. E.g. you could add scripts for https://addons.mozilla.org/de/firefox/addon/greasemonkey[greasemonkey] or https://chrome.google.com/webstore/detail/tampermonkey[tampermonkey], as well as scripts for your database or whatever may be useful and worth to share in your team. However, to share and maintain knowledge we recommend to use a wiki.

--- a/documentation/setup.asciidoc
+++ b/documentation/setup.asciidoc
@@ -4,7 +4,7 @@ toc::[]
 = Setup
 
 == Prerequisites
-We try to make it as simple as possible for you. However, there are some minimal prerequesites:
+We try to make it as simple as possible for you. However, there are some minimal prerequisites:
 
 * You need to have a tool to extract `*.tar.gz` files (`tar` and `gzip`). On Windows use https://www.7-zip.org/[7zip]. On all other platforms this comes out of the box.
 * You need to have https://git-scm.com[git] and https://curl.haxx.se/[curl] installed. 

--- a/documentation/software.asciidoc
+++ b/documentation/software.asciidoc
@@ -5,11 +5,11 @@ toc::[]
 
 The `software` folder contains the third party tools for your IDE such as link:mvn.asciidoc[maven], link:npm.asciidoc[npm], link:java.asciidoc[java], etc. 
 With respect to the link:license.asciidoc[licensing terms] you may create a custom archive containing a `devonfw-ide` together with the required software. 
-However, to be platform indepentent and allow lightweight updates the `devonfw-ide` is capable to download and link:install.asciidoc[install] the software automatically for you.
+However, to be platform independent and allow lightweight updates the `devonfw-ide` is capable to download and link:install.asciidoc[install] the software automatically for you.
 
 == Repository
 
-By default software is downloaded via the internet from public download URLs of the according tools. However, some projects may need specific tools or tool versions that are not publically available.
+By default software is downloaded via the internet from public download URLs of the according tools. However, some projects may need specific tools or tool versions that are not publicly available.
 In such case, they can create their own software repository (e.g. in a VPN) and link:configuration.asciidoc[configure] the base URL of it via `DEVON_SOFTWARE_REPOSITORY` link:variables.asciidoc[variable].
 Then `devonfw-ide` will download all software from this repository only instead of the default public download URLs.
 This repository (URL) should be accessible within your network via HTTPS (or HTTP) and without any authentication.
@@ -41,4 +41,4 @@ If you have a sensitive project that should not be affected by such side-effects
 ```
 DEVON_SOFTWARE_PATH=
 ```
-This will disable this feature particulary for that specific sensitive `devonfw-ide` installation but let you use it for all other ones.
+This will disable this feature particularly for that specific sensitive `devonfw-ide` installation but let you use it for all other ones.

--- a/documentation/structure.asciidoc
+++ b/documentation/structure.asciidoc
@@ -22,7 +22,7 @@ The directory layout of your `devonfw-ide` will look like this:
     └── link:license.asciidoc[TERMS_OF_USE.adoc]
 ----
 
-The elements of the above structure are described in the indivudal sections. As they are hyperlinks you can simply click them to get more details.
+The elements of the above structure are described in the individual sections. As they are hyperlinks you can simply click them to get more details.
 
 == TERMS_OF_USE
-You need to agree with the https://github.com/devonfw/ide/blob/master/TERMS_OF_USE.adoc[TERMS_OF_USE] in order to use `devonfw-ide`. Everything included out of the box applies to open-source licenses. However, due to the many thrid party components with their licenses and terms we want to make this clear to all our users and be compliant.
+You need to agree with the https://github.com/devonfw/ide/blob/master/TERMS_OF_USE.adoc[TERMS_OF_USE] in order to use `devonfw-ide`. Everything included out of the box applies to open-source licenses. However, due to the many third party components with their licenses and terms we want to make this clear to all our users and be compliant.

--- a/documentation/usage.asciidoc
+++ b/documentation/usage.asciidoc
@@ -31,7 +31,7 @@ For your project you should create a git-repository for the link:settings.asciid
 
 === Distribute
 To redistribute the IDE you can decide to use the official vanilla releases of the `devonfw-ide` link:scripts.asciidoc[scripts].
-However, you may also add the cloned settings, a custom link:configuration.asciidoc[devon.properties] file, or predefine link:software.asciidoc[software] (be aware of multi-plattform-support).
+However, you may also add the cloned settings, a custom link:configuration.asciidoc[devon.properties] file, or predefine link:software.asciidoc[software] (be aware of multi-platform-support).
 
 === Update
 When you have done changes in a larger project (big team), please first test the changes yourself, then pick a pilot user of the team, and only after that works well for a couple of days inform the entire team to update.

--- a/documentation/variables.asciidoc
+++ b/documentation/variables.asciidoc
@@ -5,29 +5,29 @@ toc::[]
 
 The `devonfw-ide` defines a set of standard variables to your environment for link:configuration.asciidoc[configuration] via `variables[.bat]` files.
 These environment variables are described by the following table.
-Those variables printed *bold* are also exported in your shell (except for windows CMD that does not have such concept). Variabels with the value `-` are not set by default but may be set via link:configuration.asciidoc[configuration] to override defaults.
+Those variables printed *bold* are also exported in your shell (except for windows CMD that does not have such concept). Variables with the value `-` are not set by default but may be set via link:configuration.asciidoc[configuration] to override defaults.
 Please note that we are trying to minimize any potential side-effect from `devonfw-ide` to the outside world by reducing the number of variables and only exporting those that are required.
 
-.Varialbes of devonfw-ide
+.Variables of devonfw-ide
 [options="header"]
 |=======================
 |*Variable*|*Value*|*Meaning*
-|`DEVON_IDE_HOME`|e.g. `/projects/my-project`|The toplevel directory of your `devonfw-ide` link:structure.asciidoc[structure].
+|`DEVON_IDE_HOME`|e.g. `/projects/my-project`|The top level directory of your `devonfw-ide` link:structure.asciidoc[structure].
 |`PATH`|`$PATH:$DEVON_IDE_HOME/software/java:...`|You system path is adjusted by `devon` link:cli.asciidoc[command].
 |`DEVON_HOME_DIR`|`~`|The platform independent home directory of the current user. In some edge-cases (e.g. in cygwin) this differs from `~` to ensure a central home directory for the user on a single machine in any context or environment.
 |`DEVON_IDE_TOOLS`|`java mvn eclipse vscode node npm ng`|List of tools that should be installed and upgraded by default for your current IDE.
-|*`DEVON_OLD_PATH`*|`...`|A "backup" of `PATH` before it was extended by `devon` to allow restting it. Internal variable that should never be set or tweaked.
+|*`DEVON_OLD_PATH`*|`...`|A "backup" of `PATH` before it was extended by `devon` to allow recovering it. Internal variable that should never be set or tweaked.
 |*`WORKSPACE`*|`main`|The link:workspaces.asciidoc[workspace] you are currently in. Defaults to `main` if you are not inside a link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
-|`WORKSPACE_PATH`|`$DEVON_IDE_HOME/workspaces/$WORKSPACE`|Absoulte path to current link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
+|`WORKSPACE_PATH`|`$DEVON_IDE_HOME/workspaces/$WORKSPACE`|Absolute path to current link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
 |*`JAVA_HOME`*|`$DEVON_IDE_HOME/software/java`|Path to JDK
 |`SETTINGS_PATH`|`$DEVON_IDE_HOME/settings`|Path to your link:settings.asciidoc[settings]. To keep `oasp4j-ide` legacy behaviour set this to `$DEVON_IDE_HOME/workspaces/main/development/settings`.
 |*`M2_REPO`*|`$DEVON_IDE_HOME/conf/.m2/repository`|Path to your local maven repository. For projects without high security demands, you may change this to the maven default `~/.m2/repository` and share your repository amongst multiple projects.
 |*`MAVEN_HOME`*|`$DEVON_IDE_HOME/software/maven`|Path to Maven
 |*`MAVEN_OPTS`*|`-Xmx512m -Duser.home=$DEVON_IDE_HOME/conf`|Maven options
 |`DEVON_SOFTWARE_REPOSITORY`|`-`|Project specific or custom link:software.asciidoc#repository[software-repository].
-|`DEVON_SOFTWARE_PATH`|`-`|Globaly shared user-specific link:software.asciidoc#shared[local software installation location].
+|`DEVON_SOFTWARE_PATH`|`-`|Globally shared user-specific link:software.asciidoc#shared[local software installation location].
 |`ECLIPSE_VMARGS`|`-Xms128M -Xmx768M -XX:MaxPermSize=256M`|JVM options for Eclipse
-|`ECLIPSE_PLUGINS`|`-`|Array with "feature groups" and "update site URLs" to cusomize required link:eclipse.asciidoc#plugins[eclipse plugins].
+|`ECLIPSE_PLUGINS`|`-`|Array with "feature groups" and "update site URLs" to customize required link:eclipse.asciidoc#plugins[eclipse plugins].
 |`«TOOL»_VERSION`|`-`|The version of the tool `«TOOL»` to install and use (e.g. `ECLIPSE_VERSION` or `MAVEN_VERSION`).
 |`«TOOL»_BUILD_OPTS`|e.g.`clean install`|The arguments provided to the build-tool `«TOOL»` in order to run a build.
 |`«TOOL»_RELEASE_OPTS`|e.g.`clean deploy -Dchangelist= -Pdeploy`|The arguments provided to the build-tool `«TOOL»` in order to perform a release build.

--- a/documentation/workspaces.asciidoc
+++ b/documentation/workspaces.asciidoc
@@ -3,7 +3,7 @@ toc::[]
 
 = workspaces
 
-The `workspaces` folder contains folders for your active work. There is a workspace folder `main` dedicated for your primary work. You may do all your work inside the `main` workspace. Also you are free to create any number of additional workspace folders named as you like (e.g. `test`, `release`, `testing`, `my-sub-project`, etc.). Unsing multiple workspaces is especially relevant for Eclipse as each workspace has its own Eclipse runtime instance and configuration.
+The `workspaces` folder contains folders for your active work. There is a workspace folder `main` dedicated for your primary work. You may do all your work inside the `main` workspace. Also you are free to create any number of additional workspace folders named as you like (e.g. `test`, `release`, `testing`, `my-sub-project`, etc.). Using multiple workspaces is especially relevant for Eclipse as each workspace has its own Eclipse runtime instance and configuration.
 
 Within the workspace folder (e.g. `workspaces/main`) you are again free to create sub-folders for (sub-)projects according to your needs. We assume that in most cases you clone git repositories here. The following structure shows an example layout for devonfw:
 
@@ -23,4 +23,4 @@ Within the workspace folder (e.g. `workspaces/main`) you are again free to creat
 ----
 
 In the `main` workspace you may find the cloned forks for regular work (in the example e.g. `devon4j`) as a base to create pull-requests while in the `stable` workspace there is a clone of `devon4j` from the official https://github.com/devonfw/devon4j/[devon4j].
-However this is just an example. Some people like to create separate worksapces for development and maintenance branches with git others just switch between those via `git checkout`.
+However this is just an example. Some people like to create separate workspaces for development and maintenance branches with git. Other people just switch between those via `git checkout`.


### PR DESCRIPTION
Most if not all of those typos had been identified by `Spell Right` extension from Bartosz Antosik within VS Code. I have used it on macOS, where Spell Right uses the system spelling API

Link: https://github.com/bartosz-antosik/vscode-spellright
License:  [MIT License](https://github.com/bartosz-antosik/vscode-spellright/blob/master/LICENSE.md) 