### PR TITLE
#59: improved cobigen-cli

### DIFF
--- a/documentation/cli.asciidoc
+++ b/documentation/cli.asciidoc
@@ -31,6 +31,7 @@ Technically a commandlet is a bash script located in `$DEVON_IDE_HOME/scripts/co
 The following commandlets are currently available:
 
 * link:build.asciidoc[build]
+* link:cobigen.asciidoc[cobigen]
 * link:eclipse.asciidoc[eclipse]
 * link:gradle.asciidoc[gradle]
 * link:help.asciidoc[help]

--- a/documentation/cobigen.asciidoc
+++ b/documentation/cobigen.asciidoc
@@ -1,0 +1,18 @@
+:toc:
+toc::[]
+
+= cobigen
+
+The `cobigen` commandlet allows to install, configure, and launch https://github.com/devonfw/cobigen[CobiGen] via CLI. Calling `devon cobigen «args»` is more or less the same as calling `cobigen «args»` (or `cg «args»`) but with the benefit that the version of CobiGen preferred by your project is used (and will be installed if not yet available).
+
+The arguments (`devon cobigen «args»`) are explained by the following table:
+
+.Usage of `devon cobigen`
+[options="header"]
+|=======================
+|*Argument(s)*   |*Meaning*
+|`setup`         |setup CobiGen (install and verify), link:configuration.asciidoc[configurable] via `COBIGEN_VERSION`
+|`«args»`        |run CobiGen with the given arguments (`«args»`)
+|=======================
+
+Please read the actual documentation of https://github.com/devonfw/cobigen/blob/master/documentation/howto_Cobigen-CLI-generation.asciidoc#cobigen-command-line-interface-generation[CobiGen CLI] for further details.

--- a/scripts/src/main/resources/scripts/command/cobigen
+++ b/scripts/src/main/resources/scripts/command/cobigen
@@ -3,23 +3,23 @@
 source "$(dirname "${0}")"/../functions
 
 function doSetup() {
-  # We need a JDK
-  doDevonCommand java -q setup
-  # We need Maven for installing plug-ins
+  # We need Java to run and Maven for installing plug-ins
   doDevonCommand mvn -q setup
   if [ -n "${1}" ] || [ ! -d "${COBIGEN_CLI_HOME}" ]
   then
-    local software_version="LATEST"
-    local download_url="https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=cli&v=${software_version}"
-
-    doDownload "${download_url}" "${software_name}.jar" "${COBIGEN_CLI_HOME}"
+    #doUpgradeMavenArtifact "${COBIGEN_CLI_HOME}" "https://repo.maven.apache.org/maven2/com/devonfw/cobigen" "cli" "${COBIGEN_VERSION:-LATEST}" ".jar"
+    
+    doDownload "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.cobigen&a=cli&v=${COBIGEN_VERSION:-LATEST}" "cobigen.jar" "${COBIGEN_CLI_HOME}"
 
     # We need to extract all needed files
-    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/${software_name}.jar' 'cobigen.bat' -d '${COBIGEN_CLI_HOME}'"
-    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/${software_name}.jar' 'cg.bat' -d '${COBIGEN_CLI_HOME}'"
-    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/${software_name}.jar' 'class-loader-agent.jar' -d '${COBIGEN_CLI_HOME}'"
-    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/${software_name}.jar' 'cobigen' -d '${COBIGEN_CLI_HOME}'"
-    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/${software_name}.jar' 'cg' -d '${COBIGEN_CLI_HOME}'"
+    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/cobigen.jar' 'cobigen.bat' -d '${COBIGEN_CLI_HOME}'"
+    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/cobigen.jar' 'cg.bat' -d '${COBIGEN_CLI_HOME}'"
+    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/cobigen.jar' 'class-loader-agent.jar' -d '${COBIGEN_CLI_HOME}'"
+    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/cobigen.jar' 'cobigen' -d '${COBIGEN_CLI_HOME}'"
+    doRunCommand "unzip -q '${COBIGEN_CLI_HOME}/cobigen.jar' 'cg' -d '${COBIGEN_CLI_HOME}'"
+    
+    chmod a+x "${COBIGEN_CLI_HOME}/cg"
+    chmod a+x "${COBIGEN_CLI_HOME}/cobigen"
 
     doExtendPath "${COBIGEN_CLI_HOME}"
     doEcho "To be fully functional please rerun 'devon' command to update your PATH properly."
@@ -44,8 +44,7 @@ function doRunCLI() {
 }
 
 # CLI
-software_name="cobigen"
-COBIGEN_CLI_HOME="${DEVON_IDE_HOME}/software/${software_name}-cli"
+COBIGEN_CLI_HOME="${DEVON_IDE_HOME}/software/cobigen-cli"
 if [ "${1}" = "-h" ] || [ "${1}" = "help" ]
 then
   echo "Setup CobiGen CLI."

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -394,9 +394,9 @@ function doExtract() {
   if [ "${filename_base/*\./.}" = ".tar" ] || [ "${ext}" = ".tar" ] || [ "${ext}" = ".tgz" ] || [ "${ext}" = ".tbz2" ]
   then
     doRunCommand "tar xf '${1}' -C '${target_dir}'"
-  elif [ "${ext}" = ".zip" ]
+  elif [ "${ext}" = ".zip" ] || [ "${ext}" = ".jar" ]
   then
-    doRunCommand "unzip -q '${1}' -d '${target_dir}'"
+    doRunCommand "unzip -qn '${1}' -d '${target_dir}'"
   elif [ "${ext}" = ".dmg" ]
   then
     local mount_dir="${DEVON_IDE_HOME}/updates/volume"


### PR DESCRIPTION
For issue #59: 
* added (minimal) documentation
* support for extracting *.jar files in `doExtract`
* support for unzipping crappy *.zip or *.jar files that contain the exact same file multiple times without prompting the user with confusing questions
* set executable flags so it also works on MacOS and Linux
* prepared for future releases to be installed with ability to update