### PR TITLE
#343: Detect non-admin GitForWindows and Cygwin

### DIFF
--- a/scripts/src/main/resources/scripts/devon.bat
+++ b/scripts/src/main/resources/scripts/devon.bat
@@ -35,7 +35,8 @@ if "%1%" == "" (
   goto :setup_env
 )
 
-for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "HKLM\Software\GitForWindows" /v "InstallPath" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set GIT_HOME=%%P
+rem Search GitForWindows Installation - prefer user over machine result
+for %%H in ( HKEY_LOCAL_MACHINE HKEY_CURRENT_USER ) do for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "%%H\Software\GitForWindows" /v "InstallPath" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set GIT_HOME=%%P
 
 if exist "%GIT_HOME%\bin\bash.exe" (
   set "BASH=%GIT_HOME%\bin\bash.exe"
@@ -43,7 +44,8 @@ if exist "%GIT_HOME%\bin\bash.exe" (
   goto :bash_detected
 )
 
-for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "HKLM\Software\Cygwin\setup" /v "rootdir" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set CYGWIN_HOME=%%P
+rem If bash in GitForWindows could not be found search Cygwin Installation - prefer user over machine result
+for %%H in ( HKEY_LOCAL_MACHINE HKEY_CURRENT_USER ) do for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "%%H\Software\Cygwin\setup" /v "rootdir" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set CYGWIN_HOME=%%P
 
 if exist "%CYGWIN_HOME%\bin\bash.exe" (
   set "BASH=%CYGWIN_HOME%\bin\bash.exe"


### PR DESCRIPTION
Non-Admin installations of GitForWindows and Cygwin change the registry under hive HKEY_CURRENT_USER, not HKEY_LOCAL_MACHINE.
Looping over both hives - with user hive as second - will detect also non-admin installation. If both exist, the user installation gets priority.

The current implementation always searches for both machine and user level setup inside registry. If the number of registry read shall be minimized the script would need to be rewritten accordingly.