### PR TITLE
#363: Add git pull for already existing ide settings fixes #363

### DIFF
--- a/scripts/src/main/resources/scripts/command/ide
+++ b/scripts/src/main/resources/scripts/command/ide
@@ -73,6 +73,8 @@ function doUpdateSettings() {
       git commit -m "Initial settings downloaded from ${SETTINGS_URL}"
       cd - || exit 255
     fi
+  else
+    doGitPullOrClone "${SETTINGS_PATH}"
   fi
 }
 


### PR DESCRIPTION
The current code for `devon ide update settings` only covers the case, there is no settings sub-directory yet.  This change adds handling for the case, it already exists:  The already existing function `doGitPullOrClone` is called now and will ensure, a `git pull` is executed to update the settings from the origin repository, when possible.

Since I don't actively host a real settings repository, I only have executed a simple test. Technically this change covers the "update settings" (with already existing settings dir) now. I'm just a bit unsure, if there might be some corner case - e.g. specific changes in settings - that may need some additional handling after the pure `git pull`. 

E.g. some of the *.properties files are copied to location outside of the settings sub-directory on initial setup. Does that needs to be re-executed after this update also? How to handle potential overwrites of a user-only change within the target file in this case?

I assume, this needs a bit more work to make this PR more complete.