### PR TITLE
Fixed IntelliJ launch location for Windows

### DIFF
--- a/scripts/src/main/resources/scripts/command/intellij
+++ b/scripts/src/main/resources/scripts/command/intellij
@@ -66,7 +66,7 @@ function doStartIntellij() {
   then
     open "${IDEA_HOME}/idea" --args "${@}"
   else
-    "${IDEA_HOME}/idea" "${@}" &
+    "${IDEA_HOME}/bin/idea" "${@}" &
   fi
 }
 


### PR DESCRIPTION
Tested on Windows 7, 10.