### PR TITLE
#390: prefer ci-friendly .mvn/maven.config if present for get-version

### DIFF
--- a/scripts/src/main/resources/scripts/command/mvn
+++ b/scripts/src/main/resources/scripts/command/mvn
@@ -42,7 +42,31 @@ function doSetup() {
 function doGetProjectVersion() {
   doSetup
   local maven_project_version
-  maven_project_version="$("${MVN}" -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -DforceStdout)"
+  if [ -e ".mvn/maven.config" ]
+  then
+    # https://maven.apache.org/maven-ci-friendly.html
+    local maven_config
+    maven_config="$(cat .mvn/maven.config)"
+    local maven_revision
+    maven_revision=${maven_config/#*-Drevision=}
+    if [ "${maven_revision}" != "${maven_config}" ]
+    then
+      maven_revision=${maven_revision/ */}
+      local maven_changelist
+      maven_changelist=${maven_config/#*-Dchangelist=}
+      if [ "${maven_changelist}" != "${maven_config}" ]
+      then
+        maven_changelist=${maven_changelist/ */}
+        maven_project_version="${maven_revision}${maven_changelist}"
+      else
+        maven_project_version="${maven_revision}"
+      fi
+    fi  
+  fi
+  if [ -z "${maven_project_version}" ]
+  then
+    maven_project_version="$("${MVN}" -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -DforceStdout)"
+  fi
   if [ "${maven_project_version}" = "dev-SNAPSHOT" ]
   then
     local cwd="${PWD}"


### PR DESCRIPTION
And again a fix for #390 (maven is really a strange tool and was otherwise executing project tests in devonfw-ide itself when `org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate` was called.