### PR TITLE
Use explicit arithmetic expansion

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1094,7 +1094,7 @@ function doGetNextVersion() {
     do
       if [[ ! "${begin:(${i}):1}" =~ [0-9] ]]
       then
-        i=${i}+1
+        i=$((i+1))
         break
       fi
     done


### PR DESCRIPTION
Avoid variable value like "7+1" and resolve the arithmetic expansion already within this first reassignment to variable i.