### PR TITLE
Add DEVON_IDE_TRACE to scripts

### DIFF
--- a/documentation/variables.asciidoc
+++ b/documentation/variables.asciidoc
@@ -32,4 +32,5 @@ Please note that we are trying to minimize any potential side-effect from `devon
 |`«TOOL»_VERSION`|`-`|The version of the tool `«TOOL»` to install and use (e.g. `ECLIPSE_VERSION` or `MAVEN_VERSION`).
 |`«TOOL»_BUILD_OPTS`|e.g.`clean install`|The arguments provided to the build-tool `«TOOL»` in order to run a build.
 |`«TOOL»_RELEASE_OPTS`|e.g.`clean deploy -Dchangelist= -Pdeploy`|The arguments provided to the build-tool `«TOOL»` in order to perform a release build.
+|`DEVON_IDE_TRACE`||If value is not an empty string, the `devonfw-ide` scripts will trace each script line executed. For bash two lines output: before and again after expansion.
 |=======================

--- a/scripts/src/main/resources/scripts/command/build
+++ b/scripts/src/main/resources/scripts/command/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/cicdgen
+++ b/scripts/src/main/resources/scripts/command/cicdgen
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/cobigen
+++ b/scripts/src/main/resources/scripts/command/cobigen
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/eclipse
+++ b/scripts/src/main/resources/scripts/command/eclipse
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 L_PWD=$(pwd)

--- a/scripts/src/main/resources/scripts/command/gradle
+++ b/scripts/src/main/resources/scripts/command/gradle
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/help
+++ b/scripts/src/main/resources/scripts/command/help
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 echo

--- a/scripts/src/main/resources/scripts/command/ide
+++ b/scripts/src/main/resources/scripts/command/ide
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 DEVON_IDE_REPO_URL="https://repo.maven.apache.org/maven2/com/devonfw/tools/ide"

--- a/scripts/src/main/resources/scripts/command/intellij
+++ b/scripts/src/main/resources/scripts/command/intellij
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 cd "${DEVON_IDE_HOME}" || exit 255

--- a/scripts/src/main/resources/scripts/command/ionic
+++ b/scripts/src/main/resources/scripts/command/ionic
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/java
+++ b/scripts/src/main/resources/scripts/command/java
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/jenkins
+++ b/scripts/src/main/resources/scripts/command/jenkins
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/mvn
+++ b/scripts/src/main/resources/scripts/command/mvn
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/ng
+++ b/scripts/src/main/resources/scripts/command/ng
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/node
+++ b/scripts/src/main/resources/scripts/command/node
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/npm
+++ b/scripts/src/main/resources/scripts/command/npm
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/project
+++ b/scripts/src/main/resources/scripts/command/project
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/release
+++ b/scripts/src/main/resources/scripts/command/release
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/sonar
+++ b/scripts/src/main/resources/scripts/command/sonar
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 cd "${DEVON_IDE_HOME}" || exit 255

--- a/scripts/src/main/resources/scripts/command/yarn
+++ b/scripts/src/main/resources/scripts/command/yarn
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 

--- a/scripts/src/main/resources/scripts/devon
+++ b/scripts/src/main/resources/scripts/devon
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # Source this script from a linux shell to setup the environment variables for the corresponding project.
 # hash bang only for filetype detection and editor syntax support
 

--- a/scripts/src/main/resources/scripts/devon.bat
+++ b/scripts/src/main/resources/scripts/devon.bat
@@ -1,4 +1,5 @@
 @echo off
+if NOT "%DEVON_IDE_TRACE%"=="" echo on
 if "%1%" == "-v" (
   goto :print_version
 )

--- a/scripts/src/main/resources/scripts/environment-project
+++ b/scripts/src/main/resources/scripts/environment-project
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # Script to setup devonfw-ide environment. Will actually be sourced,
 # hash bang only for filetype detection and editor syntax support
 

--- a/scripts/src/main/resources/scripts/environment-project.bat
+++ b/scripts/src/main/resources/scripts/environment-project.bat
@@ -1,5 +1,6 @@
 rem This batch is not supposed to be called manually
 @echo off
+if NOT "%DEVON_IDE_TRACE%"=="" echo on
 
 call :load_properties "%DEVON_IDE_HOME%\scripts\devon.properties"
 call :load_properties "%USERPROFILE%\devon.properties"

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+if [ -n "${DEVON_IDE_TRACE}" ]; then set -vx; fi
 # Functions to be reused in devonfw-ide commands. Will actually be sourced,
 # hash bang only for filetype detection and editor syntax support
 

--- a/scripts/src/main/resources/setup.bat
+++ b/scripts/src/main/resources/setup.bat
@@ -1,4 +1,5 @@
 @echo off
+if NOT "%DEVON_IDE_TRACE%"=="" echo on
 
 pushd %~dp0
 echo Setting up your devonfw-ide in %CD%


### PR DESCRIPTION
for #261

Variable renamed to start with DEVON_ (not DEVONFW_) in order to not introduce another namespace prefix.

The trigger line could also be moved into `functions` instead  (for most scripts) - but then the call of `functions` itself would not be traced - which makes it harder to read the generated trace logs.

