### PR TITLE
fix vscode extension installation + introduced extension cleanup

### DIFF
--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -51,14 +51,12 @@ function cleanupPlugins() {
 function doAddPlugins() {
   local file
   local pluginsToInstall
-  local pluginsToUninstall
   for file in "${SETTINGS_PATH}"/vscode/plugins/*.properties
   do
     if [ -f "${file}" ]
     then
       plugin_id=""
       plugin_active="true"
-	  force_uninstall="false"
       doLoadProperties "${file}"
       if [ -z "${plugin_id}" ]
       then
@@ -74,7 +72,7 @@ function doAddPlugins() {
 }
 
 function doInstallPlugins() {
-  if [ ! -z "${1}" ]
+  if [ -n "${1}" ]
   then
 	doEchoAttention "Execute plugin installation with following parameters (${1}) into VS code...\nPlease wait until VSCode has successfully installed all plugins.\nYou may then use or close VSCode as you like."
     doRunVsCode --force "${1}"

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -29,33 +29,58 @@ function doSetup() {
         chmod a+x "${VSCODE_HOME}/bin/code"
       fi
     fi
+	
+    cleanupPlugins
     doAddPlugins
+  fi
+}
+
+function cleanupPlugins() {
+  clean_plugins_on_update="false"
+  doLoadProperties "${SETTINGS_PATH}"/vscode/vscode.properties
+
+  if [ "${clean_plugins_on_update}" = "true" ]
+  then
+    doEcho "Cleaning up all extensions"
+    doRunCommand "rm -Rf ${DEVON_IDE_HOME}/software/vscode-extensions/*"
+  else
+    doEcho "vsCode extensions not configured to be removed on update. If you would like to do so, please create ${SETTINGS_PATH}/vscode/vscode.properties with clean_plugins_on_update=true."
   fi
 }
 
 function doAddPlugins() {
   local file
+  local pluginsToInstall
+  local pluginsToUninstall
   for file in "${SETTINGS_PATH}"/vscode/plugins/*.properties
   do
     if [ -f "${file}" ]
     then
       plugin_id=""
       plugin_active="true"
+	  force_uninstall="false"
       doLoadProperties "${file}"
       if [ -z "${plugin_id}" ]
       then
         doWarning "Invalid vscode plugin config: ${file}"
       elif [ "${plugin_active}" = "true" ]
       then
-        doAddPlugin "${plugin_id}"
+        pluginsToInstall="${pluginsToInstall} --install-extension ${plugin_id}"
       fi
     fi
   done
+
+  doInstallPlugins "${pluginsToInstall}"
 }
 
-function doAddPlugin() {
-  doEchoAttention "Installing plugin (${1}) into VS code...\nPlease wait until VSCode has successfully installed all plugins.\nYou may then use or close VSCode as you like."
-  doRunVsCode --force --install-extension "${1}" &
+function doInstallPlugins() {
+  if [ ! -z "${1}" ]
+  then
+	doEchoAttention "Execute plugin installation with following parameters (${1}) into VS code...\nPlease wait until VSCode has successfully installed all plugins.\nYou may then use or close VSCode as you like."
+    doRunVsCode --force "${1}"
+  else
+    doEcho "No plugins to be installed / uninstalled"
+  fi
 }
 
 function doConfigureVsCode() {


### PR DESCRIPTION
fixing #384 (installation of vscode extensions) and introduced the new ability to cleanup extensions.
The latter is needed to allow properly replacing extensions, which could be conflicting at some time.
One example for this is the replacement of tslint by eslint with some more impacts on autoimporters and similar extensions.
I tried to run `--uninstall-extension` parameter to uninstall specific plugins, but unfortunately the command was not able to terminate successfully in case the intended extension was not available in the current vscode instance. So finally, I wrote a way to cleanup the extension folder automatically by the update process (optionally) to allow a proper plugin replacement in case it is necessary.

This PR also relates to #432 with respect to the error log of failing extension installations, but it does not fix the settings update.