### PR TITLE
#449: update devon4j version to 2020.08.001

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -2,6 +2,19 @@
 
 This file documents all notable changes to https://github.com/devonfw/ide[devonfw-ide].
 
+== 2020.08.001
+
+Update with the following bugfixes and improvements:
+
+* https://github.com/devonfw/ide/issues/432[#432]: vsCode settings are not updated
+* https://github.com/devonfw/ide/issues/446[#446]: intellij: doConfigureEclipse: command not found
+* https://github.com/devonfw/ide/issues/440[#440]: Software update may lead to inconsistent state due to windows file locks
+* https://github.com/devonfw/ide/issues/427[#427]: release: keep leading zeros
+* https://github.com/devonfw/ide/issues/450[#450]: update settings
+* https://github.com/devonfw/ide/issues/449[#449]: update to devon4j 2020.08.001
+
+The full list of changes for this release can be found in https://github.com/devonfw/ide/milestone/12?closed=1[milestone 2020.08.001].
+
 == 2020.04.004
 
 Minor update with the following bugfixes and improvements:

--- a/configurator/src/main/java/com/devonfw/tools/ide/migrator/Migrations.java
+++ b/configurator/src/main/java/com/devonfw/tools/ide/migrator/Migrations.java
@@ -168,6 +168,9 @@ public class Migrations {
             new VersionIdentifier("com.devonfw.java.modules", "devon4j-test", null, VersionIdentifier.SCOPE_TEST),
             new VersionIdentifier("com.devonfw.java.modules", "devon4j-test-junit4", null,
                 VersionIdentifier.SCOPE_TEST))
+        .and() //
+        .next().to(VersionIdentifier.ofDevon4j("2020.08.001")) //
+        .pom().replaceProperty("devon4j.version", "2020.08.001") //
         .and().next().build();
   }
 


### PR DESCRIPTION
Implements #449 (update devon4j to `2020.08.001`).
ATTENTION: PR travis build will fail unless `devon4j` release is available in maven central.