### PR TITLE
Fix args quoting for node commandlet

### DIFF
--- a/scripts/src/main/resources/scripts/command/node
+++ b/scripts/src/main/resources/scripts/command/node
@@ -45,9 +45,9 @@ function doRun() {
   doEcho "Running: node ${*}"
   if doIsQuiet
   then
-    node "${*}" > /dev/null
+    node "${@}" > /dev/null
   else
-    node "${*}"
+    node "${@}"
   fi
 }
 
@@ -93,6 +93,6 @@ case ${1} in
   doDevonCommand cicdgen node "${*}"
 ;;
 *)
-  doRun "${*}"
+  doRun "${@}"
 ;;
 esac


### PR DESCRIPTION
Fix quoting of args in array context.

Use "$@" instead of "$*" for correct quoting of each single command option. Otherwise "devon node" can't take more than one argument.