### PR TITLE
make intellij work on linux (idea.sh vs. idea)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,6 +7,7 @@ This file documents all notable changes to https://github.com/devonfw/ide[devonf
 Update with the following bugfixes and improvements:
 
 * https://github.com/devonfw/ide/issues/452[#452]: Consider support for IntelliJ Ultimate
+* https://github.com/devonfw/ide/pull/474[#474]: make intellij work on linux (idea.sh vs. idea)
 * https://github.com/devonfw/ide/pull/465[#465]: Security update for node.js and VS code
 * https://github.com/devonfw/ide/issues/467[#467]: Expansion of ~ stopped working on windows CMD (M2_HOME not properly set)
 * https://github.com/devonfw/ide/issues/461[#461]: settings still not updated: JsonMerger not writing even if target file not exists

--- a/scripts/src/main/resources/scripts/command/intellij
+++ b/scripts/src/main/resources/scripts/command/intellij
@@ -36,6 +36,10 @@ function doSetup() {
       echo -e "#!/usr/bin/env bash\n'${DEVON_IDE_HOME}/software/intellij/IntelliJ.app/Contents/MacOS/idea' \$@" > "${IDEA_HOME}/bin/idea"
       chmod a+x "${IDEA_HOME}/bin/idea"
     fi
+    if  [ -f "${IDEA_HOME}/bin/idea.sh" ]
+    then
+       ln -s "${IDEA_HOME}/bin/idea.sh" "${IDEA_HOME}/bin/idea"
+    fi
   fi
   if [ -n "${1}" ]
   then
@@ -70,19 +74,21 @@ function doConfigureIntellij() {
 function doStartIntellij() {
   doConfigureIntellij "-u"
   echo "launching IntelliJ..."
-  local IDEA="${IDEA_HOME}/bin/idea"
-  if [ ! -f "${IDEA}" ]
+  local IDEA="${IDEA_HOME}/bin/idea64.exe"
+  if [ ! -f "${IDEA}" ];
   then
-    IDEA="${IDEA_HOME}/bin/idea64.exe"
+	IDEA="${IDEA_HOME}/bin/idea"
   fi
-  if [ ! -f "${IDEA}" ]
+  if [ ! -f "${IDEA}" ];
   then
     IDEA="${IDEA_HOME}/idea"
   fi
   if doIsMacOs
   then
+	echo "MacOs command ${IDEA}"
     open "${IDEA}" --args "${@}"
   else
+    echo "command ${IDEA}"
     "${IDEA}" "${@}" &
   fi
 }


### PR DESCRIPTION
currently intellij support does not work properly on linux as `idea` command can not be found (on linux the executable is `idea.sh`). We should therefore normalize this as done for other tools and platforms.