### PR TITLE
add IDEA_HOME to PATH after installation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@ Update with the following bugfixes and improvements:
 * https://github.com/devonfw/ide/pull/474[#474]: make intellij work on linux (idea.sh vs. idea)
 * https://github.com/devonfw/ide/pull/475[#475]: IntelliJ edition support not working properly
 * https://github.com/devonfw/ide/pull/477[#477]: update IntelliJ to 2020.2.1
+* https://github.com/devonfw/ide/pull/478[#478]: add IDEA_HOME to PATH after installation
 * https://github.com/devonfw/ide/pull/465[#465]: Security update for node.js and VS code
 * https://github.com/devonfw/ide/issues/467[#467]: Expansion of ~ stopped working on windows CMD (M2_HOME not properly set)
 * https://github.com/devonfw/ide/issues/461[#461]: settings still not updated: JsonMerger not writing even if target file not exists

--- a/scripts/src/main/resources/scripts/command/intellij
+++ b/scripts/src/main/resources/scripts/command/intellij
@@ -40,6 +40,7 @@ function doSetup() {
     then
        ln -s "${IDEA_HOME}/bin/idea.sh" "${IDEA_HOME}/bin/idea"
     fi
+    export PATH="${IDEA_HOME}/bin:${PATH}"
   fi
   if [ -n "${1}" ]
   then

--- a/scripts/src/main/resources/scripts/command/intellij
+++ b/scripts/src/main/resources/scripts/command/intellij
@@ -78,7 +78,7 @@ function doStartIntellij() {
   local IDEA="${IDEA_HOME}/bin/idea64.exe"
   if [ ! -f "${IDEA}" ];
   then
-	IDEA="${IDEA_HOME}/bin/idea"
+    IDEA="${IDEA_HOME}/bin/idea"
   fi
   if [ ! -f "${IDEA}" ];
   then
@@ -86,7 +86,7 @@ function doStartIntellij() {
   fi
   if doIsMacOs
   then
-	echo "MacOs command ${IDEA}"
+    echo "MacOs command ${IDEA}"
     open "${IDEA}" --args "${@}"
   else
     echo "command ${IDEA}"


### PR DESCRIPTION
add `IDEA_HOME/bin` to `PATH` after installation as otherwise `command -v idea` will fail.