### PR TITLE
#479: fixed add plugin via CLI

### DIFF
--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -68,11 +68,10 @@ function doAddPlugins() {
       fi
     fi
   done
-
-  doInstallPlugins "${pluginsToInstall}"
+  doAddPlugin "${pluginsToInstall}"
 }
 
-function doInstallPlugins() {
+function doAddPlugin() {
   if [ -n "${1}" ]
   then
     doEchoAttention "Execute plugin installation with following parameters (${1}) into VS code...\nPlease wait until VSCode has successfully installed all plugins.\nYou may then use or close VSCode as you like."


### PR DESCRIPTION
Fixes bug issue #479 by renaming function aligned with `eclipse` commandlet for better maintainability.