### PR TITLE
#483: fixed node tool installations

### DIFF
--- a/scripts/src/main/resources/scripts/command/ng
+++ b/scripts/src/main/resources/scripts/command/ng
@@ -8,7 +8,7 @@ function doSetup() {
   if [ ! -x "${NG_CMD}" ]
   then
     doDevonCommand node -q setup
-    doDevonCommand npm install -g @angular/cli@latest --unsafe install angular-cli
+    doDevonCommand npm install -g @angular/cli@latest
   else
     doEcho "ng is already installed at ${NG_CMD}"
   fi

--- a/scripts/src/main/resources/scripts/command/ng
+++ b/scripts/src/main/resources/scripts/command/ng
@@ -5,20 +5,12 @@ source "$(dirname "${0}")"/../functions
 
 # $1: optional setup
 function doSetup() {
-  if command -v ng &> /dev/null
+  if [ ! -x "${NG_CMD}" ]
   then
-    if [ -n "${1}" ]
-    then
-      echo "angular-cli (ng) is already installed at $(command -v ng)"
-    fi
+    doDevonCommand node -q setup
+    doDevonCommand npm install -g @angular/cli@latest --unsafe install angular-cli
   else
-    doDevonCommand npm -q setup
-    local npm_command="${DEVON_IDE_HOME}/software/node/npm"
-    if [ ! -x "${npm_command}" ]
-    then
-      npm_command="${DEVON_IDE_HOME}/software/node/bin/npm"
-    fi
-    doRunCommand "'${npm_command}' install -g @angular/cli@latest --unsafe" "install angular-cli"
+    doEcho "ng is already installed at ${NG_CMD}"
   fi
 }
 
@@ -36,6 +28,11 @@ then
   echo "Options:"
   exit
 fi
+NG_CMD="${DEVON_IDE_HOME}/software/node/ng"
+if [ ! -x "${NG_CMD}" ]
+then
+  NG_CMD="${DEVON_IDE_HOME}/software/node/bin/ng"
+fi
 
 if [ -z "${1}" ] || [ "${1}" = "setup" ]
 then
@@ -51,5 +48,5 @@ then
   doDevonCommand cicdgen ng "${*}"
 else
   doSetup
-  ng "${@}"
+  "${NG_CMD}" "${@}"
 fi

--- a/scripts/src/main/resources/scripts/command/node
+++ b/scripts/src/main/resources/scripts/command/node
@@ -51,10 +51,7 @@ function doRun() {
   fi
 }
 
-if [ -z "${NODE_HOME}" ]
-then
-  NODE_HOME="${DEVON_IDE_HOME}/software/node"
-fi
+NODE_HOME="${DEVON_IDE_HOME}/software/node"
 
 #CLI
 case ${1} in 

--- a/scripts/src/main/resources/scripts/command/npm
+++ b/scripts/src/main/resources/scripts/command/npm
@@ -5,14 +5,11 @@ source "$(dirname "${0}")"/../functions
 
 # $1: optional setup
 function doSetup() {
-  if command -v npm &> /dev/null
+  if [ ! -x "${NPM_CMD}" ]
   then
-    if [ -n "${1}" ]
-    then
-      doEcho "npm is already installed at $(command -v npm)"
-    fi
-  else
     doDevonCommand node -q setup
+  else
+    doEcho "npm is already installed at ${NPM_CMD}"
   fi
 }
 
@@ -52,9 +49,9 @@ function doRunBuild() {
   doEcho "Running: npm ${*}"
   if doIsQuiet
   then
-    npm --quiet "${@}"
+    "${NPM_CMD}" --quiet "${@}"
   else
-    npm "${@}"
+    "${NPM_CMD}" "${@}"
   fi
 }
 
@@ -79,6 +76,12 @@ then
   echo "Options:"
   exit
 fi
+NPM_CMD="${DEVON_IDE_HOME}/software/node/npm"
+if [ ! -x "${NPM_CMD}" ]
+then
+  NPM_CMD="${DEVON_IDE_HOME}/software/node/bin/npm"
+fi
+
 if [ -z "${1}" ] || [ "${1}" = "build" ]
 then
   if [ -n "${NPM_BUILD_OPTS}" ]


### PR DESCRIPTION
Fixes bug issue #483 and ensures that `node`, `npm` and `ng` are always taken from `devonfw-ide` sandbox installtion avoiding side effects from global installations.