### PR TITLE
#545: migrations for devon4j 2021.04.001

### DIFF
--- a/configurator/src/main/java/com/devonfw/tools/ide/migrator/Migrations.java
+++ b/configurator/src/main/java/com/devonfw/tools/ide/migrator/Migrations.java
@@ -181,6 +181,12 @@ public class Migrations {
         .replaceProperty("devon4j.version", "2020.12.002") //
         .replaceProperty("spring.boot.version", "2.4.0") //
         .replaceProperty("guava.version", "30.0-jre") //
+        .and() //
+        .next().to(VersionIdentifier.ofDevon4j("2021.04.001")).pom() //
+        .replaceProperty("devon4j.version", "2021.04.001") //
+        .replaceProperty("spring.boot.version", "2.4.4") //
+        .replaceProperty("jackson.version", "2.12.2") //
+        .replaceProperty("guava.version", "30.1.1-jre") //
         .and().next().build();
   }
 


### PR DESCRIPTION
WIP for #545 (devon4j not yet released, ide-settings not yet updated: https://github.com/devonfw/ide-settings/blob/master/eclipse/archetype-catalog.xml#L9).