### PR TITLE
#513: create start scripts

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,7 @@ Update with the following bugfixes and improvements:
 * https://github.com/devonfw/ide/issues/545[#545]: update devon4j to 2021.04.001 and add migration
 * https://github.com/devonfw/ide/issues/546[#546]: Problems with tm-terminal Eclipse plugin
 * https://github.com/devonfw/ide/issues/553[#553]: VSCode user-data-dir shall be part of workspace config
+* https://github.com/devonfw/ide/issues/513[#513]: Configurable generation of IDE start scripts
 
 The full list of changes for this release can be found in https://github.com/devonfw/ide/milestone/18?closed=1[milestone 2021.04.001].
 

--- a/documentation/variables.asciidoc
+++ b/documentation/variables.asciidoc
@@ -15,8 +15,9 @@ Please note that we are trying to minimize any potential side-effect from `devon
 |`DEVON_IDE_HOME`|e.g. `/projects/my-project`|The top level directory of your `devonfw-ide` link:structure.asciidoc[structure].
 |`PATH`|`$PATH:$DEVON_IDE_HOME/software/java:...`|You system path is adjusted by `devon` link:cli.asciidoc[command].
 |`DEVON_HOME_DIR`|`~`|The platform independent home directory of the current user. In some edge-cases (e.g. in cygwin) this differs from `~` to ensure a central home directory for the user on a single machine in any context or environment.
-|`DEVON_IDE_TOOLS`|`java mvn eclipse vscode node npm ng ionic`|List of tools that should be installed and upgraded by default for your current IDE.
+|`DEVON_IDE_TOOLS`|`(java mvn node npm)`|List of tools that should be installed and upgraded by default for your current IDE.
 |`DEVON_IDE_CUSTOM_TOOLS`|`-`|List of custom tools that should be installed additionally. See link:software.asciidoc#custom[software] for further details.
+|`DEVON_CREATE_START_SCRIPTS`|`(eclipse vscode)`|List of IDEs that shall be used by developers in the project and therefore start-scripts are created on setup.
 |*`DEVON_OLD_PATH`*|`...`|A "backup" of `PATH` before it was extended by `devon` to allow recovering it. Internal variable that should never be set or tweaked.
 |*`WORKSPACE`*|`main`|The link:workspaces.asciidoc[workspace] you are currently in. Defaults to `main` if you are not inside a link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.
 |`WORKSPACE_PATH`|`$DEVON_IDE_HOME/workspaces/$WORKSPACE`|Absolute path to current link:workspaces.asciidoc[workspace]. Never touch this variable in any `varibales` file.

--- a/scripts/src/main/resources/scripts/command/ide
+++ b/scripts/src/main/resources/scripts/command/ide
@@ -290,6 +290,12 @@ function doSetup() {
   else
     doWarning "Skipping project setup as DEVON_SKIP_PROJECT_SETUP is ${DEVON_SKIP_PROJECT_SETUP}"
   fi
+  local ide
+  for ide in "${DEVON_CREATE_START_SCRIPTS[@]}"
+  do
+    doEcho "\n*** Creating start-scripts for IDE ${ide} ***"
+    doDevonCommand "${ide}" --all create-script
+  done
 }
 
 function doUpdateProjects() {
@@ -297,14 +303,12 @@ function doUpdateProjects() {
 }
 
 function doUpdateSoftware() {
+  local tool
   for tool in "${DEVON_IDE_TOOLS[@]}"
   do
     doEcho "\n*** Setting up ${tool} ***"
     doDevonCommand "${tool}" setup
   done
-  doDevonCommand eclipse create-script
-  doDevonCommand vscode create-script
-  doDevonCommand intellij create-script
   default_repo=
   for tool in "${DEVON_IDE_CUSTOM_TOOLS[@]}"
   do

--- a/scripts/src/main/resources/scripts/devon.properties
+++ b/scripts/src/main/resources/scripts/devon.properties
@@ -5,6 +5,7 @@
 #************************************************************************************************
 
 DEVON_IDE_TOOLS=(java mvn node npm)
+DEVON_CREATE_START_SCRIPTS=(eclipse vscode)
 SETTINGS_PATH=${DEVON_IDE_HOME}/settings
 export NPM_CONFIG_USERCONFIG=${DEVON_IDE_HOME}/conf/npm/.npmrc
 


### PR DESCRIPTION
implements #513:
* instead of hardcoding the creation of IDE start scripts this is now configurable via new variable `DEVON_CREATE_START_SCRIPTS`
* the start scripts are created after project imports with `--all` option so all workspaces are considered#
* documentation and changelog was updated