### PR TITLE
#601: update nodejs default version from 14.17.3 to 14.17.6

### DIFF
--- a/scripts/src/main/resources/scripts/command/node
+++ b/scripts/src/main/resources/scripts/command/node
@@ -18,7 +18,7 @@ source "$(dirname "${0}")"/../functions
 function doSetup() {
   if [ -n "${1}" ] || [ ! -d "${NODE_HOME}" ]
   then
-    local software_version="${NODE_VERSION:-v14.17.3}"
+    local software_version="${NODE_VERSION:-v14.17.6}"
     local download_url="https://nodejs.org/dist/${software_version}/node-${software_version}"
     local software_dir="${NODE_HOME}"
     if doIsMacOs


### PR DESCRIPTION
fixes #601 and CVE-2021-22930