### PR TITLE
#678: support for EXTRA_JAVA_VERSION

### DIFF
--- a/documentation/eclipse.asciidoc
+++ b/documentation/eclipse.asciidoc
@@ -24,14 +24,15 @@ You may also supply additional arguments as `devon eclipse «args»`. These are 
 |`create-script`          |create launch script for this IDE, your current workspace and your OS
 |=======================
 
-There are variables that can be used for Eclipse. These are explained by the following table:
+There are link:variables.asciidoc[variables] that can be used for Eclipse. These are explained by the following table:
 
 .Variables of devonfw-ide for Eclipse
 [options="header"]
 |=======================
-|*Variable*|*Default-Value*|*Meaning*
-|*`ECLIPSE_VERSION`*|`2020-12`|The version of the tool Eclipse to install and use.
-|*`ECLIPSE_EDITION_TYPE`*|Java|The edition of the tool Eclipse to install and use. You can choose between Java for standard edition or JEE for enterprise edition.
+|*Variable*|*Meaning*
+|*`ECLIPSE_VERSION`*|The version of the tool Eclipse to install and use.
+|*`ECLIPSE_EDITION_TYPE`*|The edition of the tool Eclipse to install and use. You can choose between Java for standard edition or JEE for enterprise edition.
+|*`EXTRA_JAVA_VERSION`|You can set this to a different (newer) version of Java used to launch your IDE (other than `JAVA_VERSION` that is used to build your project)
 |=======================
 
 == plugins

--- a/documentation/intellij.asciidoc
+++ b/documentation/intellij.asciidoc
@@ -24,14 +24,15 @@ You may also supply additional arguments as `devon intellij «args»`. These are
 |`create-script` |create launch script for this IDE, your current workspace and your OS
 |=======================
 
-There are variables that can be used for IntelliJ. These are explained by the following table:
+There are link:variables.asciidoc[variables] that can be used for IntelliJ. These are explained by the following table:
 
 .Variables of devonfw-ide for intelliJ
 [options="header"]
 |=======================
-|*Variable*|*Default-Value*|*Meaning*
-|*`INTELLIJ_VERSION`*|`latest_tested_version`|The version of the tool IntelliJ to install and use.
-|*`INTELLIJ_EDITION_TYPE`*|`C`|The edition of the tool IntelliJ to install and use. The value `C` mean Community edition and the value `U` mean Ultimate edition. The Ultimate edition requires a license. The user has to buy the license separately and it is not part of devonfw-ide. The devonfw-ide only supports download and installation.
+|*Variable*|*Meaning*
+|*`INTELLIJ_VERSION`*|The version of the tool IntelliJ to install and use.
+|*`INTELLIJ_EDITION_TYPE`*|The edition of the tool IntelliJ to install and use. The value `C` mean Community edition and the value `U` mean Ultimate edition. The Ultimate edition requires a license. The user has to buy the license separately and it is not part of devonfw-ide. The devonfw-ide only supports download and installation.
+|*`EXTRA_JAVA_VERSION`|You can set this to a different (newer) version of Java used to launch your IDE (other than `JAVA_VERSION` that is used to build your project)
 |=======================
 
 == plugins

--- a/documentation/java.asciidoc
+++ b/documentation/java.asciidoc
@@ -16,6 +16,8 @@ The arguments (`devon java «args»`) are explained by the following table:
 |`cicd «args»`                       |generate cicd files for the current devon4java project
 |=======================
 
+Since `2021.12.003` an extra version of Java can be configured via `EXTRA_JAVA_VERSION` link:variables.asciidoc[variable]. This can be used to launch your IDE with a different (newer) version of Java but keeping the build of your project stable.
+
 == create
 
 Examples for create a new devon4j application:

--- a/documentation/variables.asciidoc
+++ b/documentation/variables.asciidoc
@@ -31,7 +31,7 @@ Please note that we are trying to minimize any potential side-effect from `devon
 |`ECLIPSE_VMARGS`|`-Xms128M -Xmx768M -XX:MaxPermSize=256M`|JVM options for Eclipse
 |deprecated: `ECLIPSE_PLUGINS`|`-`|Array with "feature groups" and "update site URLs" to customize required link:eclipse.asciidoc#plugins[eclipse plugins]. Deprecated - see link:eclipse.asciidoc#plugins[Eclipse plugins].
 |`«TOOL»_VERSION`|`-`|The version of the tool `«TOOL»` to install and use (e.g. `ECLIPSE_VERSION` or `MAVEN_VERSION`).
-|`EXTRA_JAVA_VERSION`|`-`|An additional (newer) version of link:java .asciidoc[java] that will be used to run java-based IDEs (e.g. link:eclipse.asciidoc[eclipse] or link:intellij.asciidoc[intellij]).
+|`EXTRA_JAVA_VERSION`|`-`|An additional (newer) version of link:java.asciidoc[java] that will be used to run java-based IDEs (e.g. link:eclipse.asciidoc[eclipse] or link:intellij.asciidoc[intellij]).
 |`«TOOL»_BUILD_OPTS`|e.g.`clean install`|The arguments provided to the build-tool `«TOOL»` in order to run a build.
 |`«TOOL»_RELEASE_OPTS`|e.g.`clean deploy -Dchangelist= -Pdeploy`|The arguments provided to the build-tool `«TOOL»` in order to perform a release build.
 |`DEVON_IDE_TRACE`||If value is not an empty string, the `devonfw-ide` scripts will trace each script line executed. For bash two lines output: before and again after expansion. *ATTENTION:* This is not a regular variable working via `devon.properties`. Instead manually do `export DEVON_IDE_TRACE=true` in bash or `DEVON_IDE_TRACE=true` in windows CMD before running a devon command to get a trace log that you can provide to experts in order to trace down a bug and see what went wrong.

--- a/documentation/variables.asciidoc
+++ b/documentation/variables.asciidoc
@@ -31,6 +31,7 @@ Please note that we are trying to minimize any potential side-effect from `devon
 |`ECLIPSE_VMARGS`|`-Xms128M -Xmx768M -XX:MaxPermSize=256M`|JVM options for Eclipse
 |deprecated: `ECLIPSE_PLUGINS`|`-`|Array with "feature groups" and "update site URLs" to customize required link:eclipse.asciidoc#plugins[eclipse plugins]. Deprecated - see link:eclipse.asciidoc#plugins[Eclipse plugins].
 |`«TOOL»_VERSION`|`-`|The version of the tool `«TOOL»` to install and use (e.g. `ECLIPSE_VERSION` or `MAVEN_VERSION`).
+|`EXTRA_JAVA_VERSION`|`-`|An additional (newer) version of link:java .asciidoc[java] that will be used to run java-based IDEs (e.g. link:eclipse.asciidoc[eclipse] or link:intellij.asciidoc[intellij]).
 |`«TOOL»_BUILD_OPTS`|e.g.`clean install`|The arguments provided to the build-tool `«TOOL»` in order to run a build.
 |`«TOOL»_RELEASE_OPTS`|e.g.`clean deploy -Dchangelist= -Pdeploy`|The arguments provided to the build-tool `«TOOL»` in order to perform a release build.
 |`DEVON_IDE_TRACE`||If value is not an empty string, the `devonfw-ide` scripts will trace each script line executed. For bash two lines output: before and again after expansion. *ATTENTION:* This is not a regular variable working via `devon.properties`. Instead manually do `export DEVON_IDE_TRACE=true` in bash or `DEVON_IDE_TRACE=true` in windows CMD before running a devon command to get a trace log that you can provide to experts in order to trace down a bug and see what went wrong.

--- a/scripts/src/main/resources/scripts/command/eclipse
+++ b/scripts/src/main/resources/scripts/command/eclipse
@@ -29,7 +29,7 @@ function doInstallEclipsePlugin() {
   local plugin="${1/\.feature\.group*/}"
   echo "Installing eclipse plugin ${plugin} from ${2}"
   # shellcheck disable=SC2086
-  "${ECLIPSE_HOME}/eclipse" -nosplash -vm "${JAVA_HOME}/bin/java" -application org.eclipse.equinox.p2.director -repository "${2}" -installIU "${1}" -vmargs ${ECLIPSE_VMARGS}
+  "${ECLIPSE_HOME}/eclipse" -nosplash -vm "${ECLIPSE_JAVA_HOME}/bin/java" -application org.eclipse.equinox.p2.director -repository "${2}" -installIU "${1}" -vmargs ${ECLIPSE_VMARGS}
   result=${?}
   if [ "${result}" != 0 ]
   then
@@ -46,9 +46,14 @@ function doSetup() {
   if [ "${1}" != "silent" ] || [ ! -d "${ECLIPSE_HOME}" ]
   then
     local version="${ECLIPSE_VERSION:-2021-12}"
-    if [ -n "${JAVA_VERSION}" ]
+    local javaVersion="${EXTRA_JAVA_VERSION}"
+    if [ -z "${javaVersion}" ]
     then
-      doVersionCompare "${JAVA_VERSION}" "11u0"
+      javaVersion="${JAVA_VERSION}"
+    fi
+    if [ -n "${javaVersion}" ]
+    then
+      doVersionCompare "${javaVersion}" "11u0"
       if [ "${?}" == 2 ]
       then
         # Java version is lower than 11
@@ -56,7 +61,7 @@ function doSetup() {
         if [ "${?}" != 2 ]
         then
           # Eclipse version is >= 2020-09
-          doConfirmWarning "You are using eclipse version ${version} that requires Java 11 or newer.\nHowever, JAVA_VERSION is ${JAVA_VERSION} - in this setup eclipse can not work. Please update JAVA_VERSION in your settings/devon.properties!"
+          doConfirmWarning "You are using eclipse version ${version} that requires Java 11 or newer.\nHowever, [EXTRA_]JAVA_VERSION is ${javaVersion} - in this setup eclipse can not work.\nPlease update JAVA_VERSION, set EXTRA_JAVA_VERSION or downgrade ECLIPSE_VERSION in your settings/devon.properties!"
         fi
       fi
     fi
@@ -215,10 +220,10 @@ function doStartEclipse() {
   if doIsWindows
   then
     # shellcheck disable=SC2086
-    start "eclipse" /B "${ECLIPSE_HOME}/eclipsec" -clean -data "${WORKSPACE_PATH}" -keyring ~/.eclipse/.keyring -vm "${JAVA_HOME}/bin/javaw" -showlocation "${WORKSPACE}" -vmargs ${ECLIPSE_VMARGS}
+    start "eclipse" /B "${ECLIPSE_HOME}/eclipsec" -clean -data "${WORKSPACE_PATH}" -keyring ~/.eclipse/.keyring -vm "${ECLIPSE_JAVA_HOME}/bin/javaw" -showlocation "${WORKSPACE}" -vmargs ${ECLIPSE_VMARGS}
   else
     # shellcheck disable=SC2086
-    "${ECLIPSE_HOME}/eclipse" -clean -data "${WORKSPACE_PATH}" -keyring ~/.eclipse/.keyring -vm "${JAVA_HOME}/bin/java" -showlocation "${DEVON_IDE_HOME/*\//}/${WORKSPACE}" -vmargs ${ECLIPSE_VMARGS} &
+    "${ECLIPSE_HOME}/eclipse" -clean -data "${WORKSPACE_PATH}" -keyring ~/.eclipse/.keyring -vm "${ECLIPSE_JAVA_HOME}/bin/java" -showlocation "${DEVON_IDE_HOME/*\//}/${WORKSPACE}" -vmargs ${ECLIPSE_VMARGS} &
   fi
 }
 
@@ -247,7 +252,7 @@ function doImportEclipse() {
   importWorkingSets="${2}"
   echo "Starting eclipse import for ${importPath} into workspace ${WORKSPACE} at ${WORKSPACE_PATH}"
   # shellcheck disable=SC2086
-  "${ECLIPSE_HOME}/eclipse" -nosplash -vm "${JAVA_HOME}/bin/java" -application org.eclipse.ant.core.antRunner -buildfile "${DEVON_IDE_HOME}/scripts/lib_script/import.xml" -data "${WORKSPACE_PATH}" -keyring ~/.eclipse/.keyring -vm "${JAVA_HOME}/bin/java" -vmargs -DdevonImportPath="${importPath}" -DdevonImportWorkingSet="${importWorkingSets}" ${ECLIPSE_VMARGS} 
+  "${ECLIPSE_HOME}/eclipse" -nosplash -vm "${ECLIPSE_JAVA_HOME}/bin/java" -application org.eclipse.ant.core.antRunner -buildfile "${DEVON_IDE_HOME}/scripts/lib_script/import.xml" -data "${WORKSPACE_PATH}" -keyring ~/.eclipse/.keyring -vm "${ECLIPSE_JAVA_HOME}/bin/java" -vmargs -DdevonImportPath="${importPath}" -DdevonImportWorkingSet="${importWorkingSets}" ${ECLIPSE_VMARGS} 
 }
 
 # CLI
@@ -268,6 +273,11 @@ then
   exit
 fi
 ECLIPSE_HOME="${DEVON_IDE_HOME}/software/eclipse"
+ECLIPSE_JAVA_HOME="${JAVA_HOME}"
+if [ -n "${EXTRA_JAVA_VERSION}" ]
+then
+  ECLIPSE_JAVA_HOME="${DEVON_IDE_HOME}/software/extra/java"
+fi
 if [ -z "${1}" ]
 then
   doSetup silent

--- a/scripts/src/main/resources/scripts/command/intellij
+++ b/scripts/src/main/resources/scripts/command/intellij
@@ -133,6 +133,11 @@ function doConfigureIntellij() {
 
 function doStartIntellij() {
   doConfigureIntellij "-u"
+  if [ -n "${EXTRA_JAVA_VERSION}" ]
+  then
+    JAVA_HOME="${DEVON_IDE_HOME}/software/extra/java"
+    doExtendPath "${JAVA_HOME}"
+  fi
   echo "launching IntelliJ..."
   local IDEA="${IDEA_HOME}/bin/idea64.exe"
   if [ ! -f "${IDEA}" ];

--- a/scripts/src/main/resources/scripts/command/java
+++ b/scripts/src/main/resources/scripts/command/java
@@ -24,9 +24,30 @@ source "$(dirname "${0}")"/../functions
 # $1: optional setup
 function doSetup() {
   export JAVA_HOME="${DEVON_IDE_HOME}/software/java"
-  if [ "${1}" != "silent" ] || [ ! -d "${JAVA_HOME}" ]
+  local version="${JAVA_VERSION:-11.0.13_8}"
+  doSetupJava "${1}" "${version}" "${DEVON_IDE_HOME}/software" "Java"
+  if [ -n "${EXTRA_JAVA_VERSION}" ]
   then
-    local version="${JAVA_VERSION:-11.0.13_8}"
+    if [ "${EXTRA_JAVA_VERSION}" = "${version}" ]
+    then
+      doConfirmWarning "You have configured EXTRA_JAVA_VERSION=${EXTRA_JAVA_VERSION} what is the same as JAVA_VERSION.\nThis does not make any sense. Please revisit your configuration."
+    fi
+    doSetupJava "${1}" "${EXTRA_JAVA_VERSION}" "${DEVON_IDE_HOME}/software/extra" "extra-Java"
+  fi
+}
+
+# $1: mode (e.g. 'silent')
+# $2: version
+# $3: software path
+# $4: label (e.g. 'extra Java')
+function doSetupJava() {
+  local mode="${1}"
+  local version="${2}"
+  local path="${3}"
+  local javaLabel="${4}"
+  local javaHome="${path}/java"
+  if [ "${mode}" != "silent" ] || [ ! -d "${javaHome}" ]
+  then
     local code
     if [ "${version:0:1}" = "8" ]
     then
@@ -34,20 +55,24 @@ function doSetup() {
     else
       code="jdk-${version/_/%2B}"
     fi
-    doInstall "-" "${JAVA_HOME}" "java" "${version}" "" "${code}"
-    if [ ! -d "${DEVON_IDE_HOME}/software/java/bin" ] && doIsMacOs && [ -d "${DEVON_IDE_HOME}/software/java/Contents" ]
+    doInstall "-" "${javaHome}" "java" "${version}" "" "${code}"
+    if [ ! -d "${javaHome}/bin" ] && doIsMacOs && [ -d "${javaHome}/Contents" ]
     then
-      doEcho "Creating symlink as workaround for Java on MacOS"
-      doRunCommand "rm -rf '${DEVON_IDE_HOME}/software/jdk'"
-      doRunCommand "mv '${DEVON_IDE_HOME}/software/java' '${DEVON_IDE_HOME}/software/jdk'"
-      doRunCommand "ln -sf 'jdk/Contents/Home' '${DEVON_IDE_HOME}/software/java'"
-      doRunCommand "cp '${DEVON_IDE_HOME}/software/jdk/.devon.software.version' '${DEVON_IDE_HOME}/software/java'"
+      doEcho "Creating symlink as workaround for ${javaLabel} on MacOS"
+      local jdkHome="${path}/jdk"
+      doRunCommand "rm -rf '${jdkHome}'"
+      doRunCommand "mv '${javaHome}' '${jdkHome}'"
+      doRunCommand "ln -sf 'jdk/Contents/Home' '${javaHome}'"
+      doRunCommand "cp '${jdkHome}/.devon.software.version' '${javaHome}'"
     fi
-    doExtendPath "${JAVA_HOME}"
+    if [ "${javaHome}" = "${JAVA_HOME}" ]
+    then
+      doExtendPath "${JAVA_HOME}"
+    fi
   fi
-  if [ "${1}" != "silent" ] && ! doIsQuiet
+  if [ "${mode}" != "silent" ] && ! doIsQuiet
   then
-    doRunCommand "'${JAVA_HOME}/bin/java' -version" "verify installation of Java"
+    doRunCommand "'${javaHome}/bin/java' -version" "verify installation of ${javaLabel}"
   fi
 }
 


### PR DESCRIPTION
* implements #678
* includes doc update of variables
* includes support in `java` commandlet (fully tested)
* includes support in `eclipse` commandlet (fully tested)
* includes support in `intellij` commandlet
* includes doc updates for `java`, `eclipse` and `intellij`
* settings already updated to enforce proper JRE is set as default in new Eclipse workspace