### PR TITLE
#678: prevent to add extra to path

### DIFF
--- a/scripts/src/main/resources/scripts/environment-project
+++ b/scripts/src/main/resources/scripts/environment-project
@@ -129,17 +129,20 @@ fi
 SOFTWARE_PATH=${DEVON_IDE_HOME}/software
 for SOFTWARE_FOLDER in "${SOFTWARE_PATH}"/*
 do
-  if [ -d "${SOFTWARE_FOLDER}/bin" ]
+  if [ "${SOFTWARE_FOLDER}" != "${SOFTWARE_PATH}/extra" ]
   then
-    PATH="${SOFTWARE_FOLDER}/bin:${PATH}"
-  else
-    PATH="${SOFTWARE_FOLDER}:${PATH}"
-  fi
-  # Load custom configuration of software
-  if [ -e "${SOFTWARE_FOLDER}/ide-config" ]
-  then
-    # shellcheck disable=SC1090
-    source "${SOFTWARE_FOLDER}/ide-config"
+    if [ -d "${SOFTWARE_FOLDER}/bin" ]
+    then
+      PATH="${SOFTWARE_FOLDER}/bin:${PATH}"
+    else
+      PATH="${SOFTWARE_FOLDER}:${PATH}"
+    fi
+    # Load custom configuration of software
+    if [ -e "${SOFTWARE_FOLDER}/ide-config" ]
+    then
+      # shellcheck disable=SC1090
+      source "${SOFTWARE_FOLDER}/ide-config"
+    fi
   fi
 done
 

--- a/scripts/src/main/resources/scripts/environment-project.bat
+++ b/scripts/src/main/resources/scripts/environment-project.bat
@@ -34,14 +34,16 @@ if not exist "%SETTINGS_PATH%" (
 )
 setlocal EnableDelayedExpansion
 for /f "delims=" %%i in ('dir /a:d /b "%SOFTWARE_PATH%\*.*"') do (
-  if exist "%SOFTWARE_PATH%\%%i\bin" (
-    set "IDE_PATH=%SOFTWARE_PATH%\%%i\bin;!IDE_PATH!"
-  ) else (
-    set "IDE_PATH=%SOFTWARE_PATH%\%%i;!IDE_PATH!"
-  )
-  rem Load custom configuration of software
-  if exist "%SOFTWARE_PATH%\%%i\ide-config.bat" (
-    call "%SOFTWARE_PATH%\%%i\ide-config.bat"
+  if not "%%i" == "extra" (
+    if exist "%SOFTWARE_PATH%\%%i\bin" (
+      set "IDE_PATH=%SOFTWARE_PATH%\%%i\bin;!IDE_PATH!"
+    ) else (
+      set "IDE_PATH=%SOFTWARE_PATH%\%%i;!IDE_PATH!"
+    )
+    rem Load custom configuration of software
+    if exist "%SOFTWARE_PATH%\%%i\ide-config.bat" (
+      call "%SOFTWARE_PATH%\%%i\ide-config.bat"
+    )
   )
 )
 (


### PR DESCRIPTION
Improvement for #678: do not add `extra` to path.

Side-note: On MacOS for Java a workaround is needed:
* java follows MacOS app conventions but not standards of other OS
* that is has a folder `Contents` that contains subfolders `Home` and `MacOS`
* the expected layout of a JDK is within `Contents/Home` that also contains the `bin` folder that contains `java`, etc.
* However, the entire structure is required for the JDK to work
* as a workaround devonfw-ide detects this and then renames the `java` folder to `jdk` and creates a symlink `java` pointing to `jdk/Contents/Home` so everthing else works as expected.
* as a result also the `jdk` folder is put on the `PATH`. This does not cause real harm but it should also be prevented.
* Further we have the same issue also with other apps on MacOS. For Eclipse and IntelliJ we simply create launch scripts ourselves at the expected locations but this only works for "single command tools". For things like GraalVM (see #638) we will have the same problems as with Java.
* Therefore I am thinking about moving this workaround from the `java` commandlet to the `doInstall` function and make it generic. Maybe instead of renaming the folder inside `software` it could be moved to a generic subfolder (something like the new `extra` folder in `software` but to avoid conflicts it needs to be a different one - maybe just `macos` or if we expect similar workarounds also for other OS something like `internal` also excluded from the path.