### PR TITLE
improve updates for developers

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -926,8 +926,9 @@ function doUpgradeMavenArtifact() {
   fi
   url="${url}/${artifact_id}"
   local repository="${DEVON_SOFTWARE_REPOSITORY}"
-  if [ "${current_version}" = "0" ]
+  if [ "${current_version}" = "0" ] && ! doIsForce
   then
+    echo "Current version of ${artifact_id} is 0. Update is aborted. Use force (-f) to enforce update."
     return 1
   fi
   doEcho "*** Software Update of ${artifact_id} ***"
@@ -938,7 +939,7 @@ function doUpgradeMavenArtifact() {
     target_version="${LATEST_VERSION}"
     repository="-"
   fi
-  if [ -n "${current_version}" ]
+  if [ -n "${current_version}" ] && [ "${current_version}" != "0" ]
   then
     doVersionCompare "${target_version}" "${current_version}"
     result=${?}


### PR DESCRIPTION
In the source of scripts for devonfw-ide we use expressions like `$[devon_ide_version]` that are resolved during the build of a release.

https://github.com/devonfw/ide/blob/eaf71f85e6ac2346aa9dcce983d0e03adb505015/scripts/src/main/resources/scripts/command/ide#L47

Sometimes developers or early adopters might use the original scripts for testing. In such case bash will evaluate this expression to `0`. As a result in this case a command like `devon ide update scripts` does nothing at all (no output, no update).
This can be very confusing for users that end up in this situation though it may only affect very few people.
However, already for myself (in my ide for devonfw itself I use symlinks to the latest source scripts) it is nice and easy to solve that we get a little more output and also allow to proceed when force mode (-f) is used (so you are not "stuck" but get a message telling you what happened and that you can proceed with force mode so `devon ide -f update scripts` will still allow you to get the latest stable release). This is what I implemented in this PR.