### PR TITLE
Add Rancher Desktop to LICENSE.asciidoc

### DIFF
--- a/documentation/LICENSE.asciidoc
+++ b/documentation/LICENSE.asciidoc
@@ -60,6 +60,7 @@ The following table shows the components that may be used. The column `inclusion
 |https://helm.sh/[helm]|Optional|https://github.com/devonfw/ide/blob/master/LICENSE[ASL 2.0]
 |https://terraform.io/[terraform]|Optional|https://github.com/hashicorp/terraform/blob/main/LICENSE[Mozilla Public License 2.0]
 |https://www.graalvm.org/[GraalVM] |Optional|https://github.com/oracle/graal/blob/master/LICENSE[GPLv2] (with the “Classpath” Exception)
+|https://rancherdesktop.io/[Rancher Desktop]|Optional|https://github.com/rancher-sandbox/rancher-desktop/blob/main/LICENSE[ASL 2.0]
 |=======================
 
 == Apache Software License - Version 2.0


### PR DESCRIPTION
#690: Added Rancher Desktop as software with links to LICENSE-document