### PR TITLE
replace ${os} first for flexibility

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -508,8 +508,8 @@ function doDownload() {
     for mirror in "${mirrors[@]}"
     do
       local mirror_url="${mirror}"
-      mirror_url="${mirror_url//\$\{version\}/${version}}"
       mirror_url="${mirror_url//\$\{os\}/${os}}"
+      mirror_url="${mirror_url//\$\{version\}/${version}}"
       mirror_url="${mirror_url//\$\{arch\}/${arch}}"
       mirror_url="${mirror_url//\$\{ext\}/${ext}}"
       mirror_url="${mirror_url//\$\{edition\}/${edition}}"


### PR DESCRIPTION
With #641 we introduced mirrors repo with flexible configuration to build download URLs.
However, we still face tools/products that do not follow best-practices and build kind of exotic URLs that are not structured logically using a simple pattern.
As a workaround when filenames or URL paths differ per OS we want to support that instead of putting variables like `${version}`, `${arch}` or `${ext}` into URLs we put them into `os-mappings` if required so that you can build the URL or filename dependent on the operating system. E.g. Rancher-Desktop is a candidate that includes architecture (`${arch}`) in MacOS releases while they are omitted for linux and windows, etc.

We have to be aware that with previous releases of devonfw-ide this change does not apply and using it in mirrors could cause breaking changes. However, we could use it for new tools (like RancherDesktop) already and simply require the new devonfw-ide version to be in use. Also over time (after years) we can drop support for quite old releases and let the users update if all features should still be fully functional.