### PR TITLE
#746 Azure CLI for Mac Integration

### DIFF
--- a/scripts/src/main/resources/scripts/command/az
+++ b/scripts/src/main/resources/scripts/command/az
@@ -90,7 +90,7 @@ function doRun() {
     setConfigDir
     if doIsMacOs
     then
-      ${AZ_MAC_DIR}/bin/az "${@}"
+      "${AZ_MAC_DIR}"/bin/az "${@}"
     else
       az "${@}"
     fi

--- a/scripts/src/main/resources/scripts/command/az
+++ b/scripts/src/main/resources/scripts/command/az
@@ -37,6 +37,15 @@ function doSetup() {
       then
         doPackageInstall "${AZ_HOME}"
       fi   
+    elif doIsMacOs
+    then
+      doRunCommand "python3 -m venv ${AZ_MAC_HOME}"
+      doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install --upgrade pip"
+      doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install wheel"
+      doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install azure-cli"
+      setConfigDir
+    else
+      doFail "Sorry, Azure CLI installation support is not yet implemented for your OS. Please install manually or help devonfw-ide to support it for your OS by contributing a pull-request."
     fi
   fi
 }
@@ -55,13 +64,6 @@ function doPackageInstall() {
     else
       doError "The setup was canceled or failed. Rerun the setup to install Azure CLI."
     fi
-  elif doIsMacOs
-  then
-    doRunCommand "python3 -m venv ${AZ_MAC_HOME}"
-    doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install --upgrade pip"
-    doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install wheel"
-    doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install azure-cli"
-    setConfigDir
   else
     doFail "Sorry, Azure CLI installation support is not yet implemented for your OS. Please install manually or help devonfw-ide to support it for your OS by contributing a pull-request."
   fi

--- a/scripts/src/main/resources/scripts/command/az
+++ b/scripts/src/main/resources/scripts/command/az
@@ -23,21 +23,18 @@ function doSetup() {
     fi
   else
     doRequireNotBatch
-    if doIsWindows
+    # Get leatest release
+    if [ -z "${AZ_VERSION}" ]
     then
-      # Get leatest release
-      if [ -z "${AZ_VERSION}" ]
-      then
-        doEcho "Getting latest release..."
-        AZ_VERSION=$(curl -s https://api.github.com/repos/Azure/azure-cli/releases/latest | awk -F ":" '/tag_name/ {print $2}'| awk -F "\"" '{print $2}' | awk -F "-" '{print $3}')
-      fi
-
-      doInstall "-" "${AZ_HOME}" "az" "${AZ_VERSION}"
-      if [ "${?}" = 0 ]
-      then
-        doPackageInstall "${AZ_HOME}"
-      fi
+      doEcho "Getting latest release..."
+      AZ_VERSION=$(curl -s https://api.github.com/repos/Azure/azure-cli/releases/latest | awk -F ":" '/tag_name/ {print $2}'| awk -F "\"" '{print $2}' | awk -F "-" '{print $3}')
     fi
+
+    doInstall "-" "${AZ_HOME}" "az" "${AZ_VERSION}"
+    if [ "${?}" = 0 ]
+    then
+      doPackageInstall "${AZ_HOME}"
+    fi   
   fi
 }
 
@@ -55,6 +52,13 @@ function doPackageInstall() {
     else
       doError "The setup was canceled or failed. Rerun the setup to install Azure CLI."
     fi
+  elif doIsMacOs
+  then
+    doRunCommand "python3 -m venv ${AZ_MAC_HOME}"
+    doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install --upgrade pip"
+    doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install wheel"
+    doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install azure-cli"
+    setConfigDir
   else
     doFail "Sorry, Azure CLI installation support is not yet implemented for your OS. Please install manually or help devonfw-ide to support it for your OS by contributing a pull-request."
   fi
@@ -79,11 +83,17 @@ function doRun() {
   then
     doEcho "Running: Azure CLI ${*}"
     setConfigDir
-    az "${@}"
+    if doIsMacOs
+    then
+      ${AZ_MAC_HOME}/bin/az "${@}"
+    else
+      az "${@}"
+    fi
   fi
 }
 
 AZ_HOME="${DEVON_IDE_HOME}/updates/install/az"
+AZ_MAC_HOME="${DEVON_IDE_HOME}/software/azure"
 
 # CLI
 case ${1} in

--- a/scripts/src/main/resources/scripts/command/az
+++ b/scripts/src/main/resources/scripts/command/az
@@ -23,18 +23,20 @@ function doSetup() {
     fi
   else
     doRequireNotBatch
+    if doIsWindows
     # Get leatest release
-    if [ -z "${AZ_VERSION}" ]
-    then
-      doEcho "Getting latest release..."
-      AZ_VERSION=$(curl -s https://api.github.com/repos/Azure/azure-cli/releases/latest | awk -F ":" '/tag_name/ {print $2}'| awk -F "\"" '{print $2}' | awk -F "-" '{print $3}')
-    fi
+      if [ -z "${AZ_VERSION}" ]
+      then
+        doEcho "Getting latest release..."
+        AZ_VERSION=$(curl -s https://api.github.com/repos/Azure/azure-cli/releases/latest | awk -F ":" '/tag_name/ {print $2}'| awk -F "\"" '{print $2}' | awk -F "-" '{print $3}')
+      fi
 
-    doInstall "-" "${AZ_HOME}" "az" "${AZ_VERSION}"
-    if [ "${?}" = 0 ]
-    then
-      doPackageInstall "${AZ_HOME}"
-    fi   
+      doInstall "-" "${AZ_HOME}" "az" "${AZ_VERSION}"
+      if [ "${?}" = 0 ]
+      then
+        doPackageInstall "${AZ_HOME}"
+      fi   
+    fi
   fi
 }
 

--- a/scripts/src/main/resources/scripts/command/az
+++ b/scripts/src/main/resources/scripts/command/az
@@ -24,7 +24,8 @@ function doSetup() {
   else
     doRequireNotBatch
     if doIsWindows
-    # Get leatest release
+    then
+      # Get leatest release
       if [ -z "${AZ_VERSION}" ]
       then
         doEcho "Getting latest release..."

--- a/scripts/src/main/resources/scripts/command/az
+++ b/scripts/src/main/resources/scripts/command/az
@@ -39,10 +39,10 @@ function doSetup() {
       fi   
     elif doIsMacOs
     then
-      doRunCommand "python3 -m venv ${AZ_MAC_HOME}"
-      doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install --upgrade pip"
-      doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install wheel"
-      doRunCommand "${AZ_MAC_HOME}/bin/python -m pip install azure-cli"
+      doRunCommand "python3 -m venv ${AZ_MAC_DIR}"
+      doRunCommand "${AZ_MAC_DIR}/bin/python -m pip install --upgrade pip"
+      doRunCommand "${AZ_MAC_DIR}/bin/python -m pip install wheel"
+      doRunCommand "${AZ_MAC_DIR}/bin/python -m pip install azure-cli"
       setConfigDir
     else
       doFail "Sorry, Azure CLI installation support is not yet implemented for your OS. Please install manually or help devonfw-ide to support it for your OS by contributing a pull-request."
@@ -90,7 +90,7 @@ function doRun() {
     setConfigDir
     if doIsMacOs
     then
-      ${AZ_MAC_HOME}/bin/az "${@}"
+      ${AZ_MAC_DIR}/bin/az "${@}"
     else
       az "${@}"
     fi
@@ -98,7 +98,7 @@ function doRun() {
 }
 
 AZ_HOME="${DEVON_IDE_HOME}/updates/install/az"
-AZ_MAC_HOME="${DEVON_IDE_HOME}/software/azure"
+AZ_MAC_DIR="${DEVON_IDE_HOME}/software/azure"
 
 # CLI
 case ${1} in


### PR DESCRIPTION
This is a PR for the Azure CLI for Mac integration. Azure CLI for Mac can only be installed globally via homebrew, so this installation is local and is stored in the IDE in software/azure. 

The installation procedure is also possible for Windows, but this requires Python to be installed. On Mac, Python is already pre-installed. Either we do without the installation for Mac or we make this compromise. I am waiting for feedback.

PR refers to #746 