### PR TITLE
bugfix terraform and helm

### DIFF
--- a/scripts/src/main/resources/scripts/command/helm
+++ b/scripts/src/main/resources/scripts/command/helm
@@ -17,7 +17,7 @@ source "$(dirname "${0}")"/../functions
 # Call helm with specified arguments.
 function doRun() {
   doSetup silent
-  doRunCommand "${HELM_HOME}/helm" "${@}"
+  doRunCommand "${HELM_HOME}/helm ${*}"
 }
 
 function doSetup() {

--- a/scripts/src/main/resources/scripts/command/terraform
+++ b/scripts/src/main/resources/scripts/command/terraform
@@ -17,7 +17,7 @@ source "$(dirname "${0}")"/../functions
 # Call Terraform with specified arguments.
 function doRun() {
   doSetup silent
-  doRunCommand "${TERRAFORM_HOME}/terraform" "${@}"
+  doRunCommand "${TERRAFORM_HOME}/terraform ${*}"
 }
 
 function doSetup() {


### PR DESCRIPTION
when terraform and helm are used as proxy commandlets in devonfw-ide the arguments are not properly passed and as a result it is not working:
```
# devon helm env
The Kubernetes package manager

Common actions for Helm:

- helm search:    search for charts
- helm pull:      download a chart to your local directory to view
- helm install:   upload the chart to Kubernetes
- helm list:      list releases of charts
...
```
so the `env` parameter is not passed to `helm`. Same problem exists for `terraform`.