### PR TITLE
#781: removed pointless java dependency from dotnet

### DIFF
--- a/scripts/src/main/resources/scripts/command/dotnet
+++ b/scripts/src/main/resources/scripts/command/dotnet
@@ -13,7 +13,6 @@ function doExists() {
 }
 
 function doSetup() {
-  doDevonCommand java setup silent
   if [ "${1}" != "silent" ] || [ ! -d "${DOTNET_HOME}" ]
   then
     doInstall "-" "${DOTNET_HOME}" "dotnet" "${DOTNET_VERSION:-6.0.300}"


### PR DESCRIPTION
See #781: With PR #292 an unwanted dependency from DotNet to Java has been introduced.
I assume this was just copied & pasted from another commandlet.
As DotNet does not depend on Java there is no sense in this so I simply removed it.