### PR TITLE
#847 Generic way to output tool version

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1525,14 +1525,14 @@ function doCheckIsTool() {
     return 1
   fi
   tool_list=$(
-    ${HOME}/.devon/devon help | awk '
+    "${HOME}"/.devon/devon help | awk '
     BEGIN {i=0}
     /^Commands:/ {i=1; next}
     i==1 && /^$/ {i=0}
     i==0 {next}
     {gsub(/ /,""); printf"%s ", $0}
   ')
-  if [[ $(echo "${tool_list}" | awk  '! /'${tool}'/ {print "1"}') ]] || [[ $(command -v "${tool}" >/dev/null 2>&1; echo $?) != "0" ]]
+  if [[ $(echo "${tool_list}" | awk  '! /'"${tool}"'/ {print "1"}') ]] || [[ $(command -v "${tool}" >/dev/null 2>&1; echo $?) != "0" ]]
   then
     return 1
   fi

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1515,6 +1515,44 @@ function doIsEmptyDirectory() {
   fi
 }
 
+# $1: tool
+function doCheckIsTool() {
+  local tool=$(echo "${1}" | awk '{print tolower($0)}')
+  local tool_list=$(
+    ${HOME}/.devon/devon help | awk '
+    BEGIN {i=0}
+    /^Commands:/ {i=1; next}
+    i==1 && /^$/ {i=0}
+    i==0 {next}
+    {gsub(/ /,""); printf"%s ", $0}
+  ')
+  if [[ ${tool_list} != *"${tool}"* ]] || [[ $(which "${tool}" >/dev/null 2>&1; echo $?) != "0" ]]
+  then
+    return 1
+  fi
+}
+
+# $1: tool
+function doGetToolFolder() {
+  local tool=$(echo "${1}" | awk '{print tolower($0)}')
+  local cmd=""
+  local dir=""
+  if ! doCheckIsTool "${tool}"
+  then
+    return 1
+  fi
+  cmd=$(which "${tool}")
+  dir=$(dirname "${cmd}")
+  if [ $(basename "${dir}") == "bin" ]
+  then
+    dir=$(dirname "${dir}")
+  fi
+  if [ -n "${dir}" ]
+  then
+    echo "${dir}"
+  fi
+}
+
 function doIsPackageJsonContainingScript() {
   doDebug "Checking if package.json contains script section named $1"
   if sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/§/g' package.json | tr -d '\r' | grep -q "[\"']scripts[\"']\s*:\s*{\s*§.*[\"']${1}[\"']\s*:"

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1517,8 +1517,14 @@ function doIsEmptyDirectory() {
 
 # $1: tool
 function doCheckIsTool() {
-  local tool=$(echo "${1}" | awk '{print tolower($0)}')
-  local tool_list=$(
+  local tool=""
+  local tool_list=""
+  tool=$(echo "${1}" | awk '{print tolower($0)}')
+  if [ "${tool}" == "help" ]
+  then
+    return 1
+  fi
+  tool_list=$(
     ${HOME}/.devon/devon help | awk '
     BEGIN {i=0}
     /^Commands:/ {i=1; next}
@@ -1526,7 +1532,7 @@ function doCheckIsTool() {
     i==0 {next}
     {gsub(/ /,""); printf"%s ", $0}
   ')
-  if [[ ${tool_list} != *"${tool}"* ]] || [[ $(which "${tool}" >/dev/null 2>&1; echo $?) != "0" ]]
+  if [[ $(echo "${tool_list}" | awk  '! /'${tool}'/ {print "1"}') ]] || [[ $(command -v "${tool}" >/dev/null 2>&1; echo $?) != "0" ]]
   then
     return 1
   fi
@@ -1534,16 +1540,17 @@ function doCheckIsTool() {
 
 # $1: tool
 function doGetToolFolder() {
-  local tool=$(echo "${1}" | awk '{print tolower($0)}')
+  local tool=""
   local cmd=""
   local dir=""
+  tool=$(echo "${1}" | awk '{print tolower($0)}')
   if ! doCheckIsTool "${tool}"
   then
     return 1
   fi
-  cmd=$(which "${tool}")
+  cmd=$(command -v "${tool}")
   dir=$(dirname "${cmd}")
-  if [ $(basename "${dir}") == "bin" ]
+  if [[ "$(basename "${dir}")" == "bin" ]] && [[ "${dir}" = *"${DEVON_IDE_HOME}/software"* ]]
   then
     dir=$(dirname "${dir}")
   fi


### PR DESCRIPTION
#847 Generic way to output tool version

Functions to test whether a specified commandlet is installed and to determine the tool's software directory as a prerequisite for determining the current version.