### PR TITLE
#847: #826: fixes

### DIFF
--- a/documentation/functions.asciidoc
+++ b/documentation/functions.asciidoc
@@ -187,7 +187,7 @@ If the URL is not provided as first argument, it will use the `mirrors` config t
 
 |=======================
 |*Param*|*Name*  |*Description*
-|`$1`   |URL     |The explicit URL to download from or `-` to compute in xref:doDownload[].
+|`$1`   |URL     |The explicit URL to download from or `-` to compute from mirrors.
 |`$2`   |dir     |The optional target directory where to save the downloaded file.
 |`$3`   |name    |The name of the software to download.
 |`$4`   |version |The version of the software to download. May be omitted to download the latest version.
@@ -289,6 +289,9 @@ The parameters source directory, target directory, backup directory and possibly
 The first three parameters are taken directly into variables and removed from the list of passed parameters with the shift so that the last specification can be viewed as a whole.
 If the last parameter is a single directory and, on MacOS, not a directory with a name like *.app, it is taken as the source directory.
 Then the function doReplaceExtractedFile is called with the saved parameters, with source directory, target directory and backup directory.
+
+=== doUpdateMirrors
+Uses xref:doGitPullOrClone[] to clone or pull `mirrors` ensuring that everything is up-to-date.
 
 === doUnzip
 Checks if an unzip program is installed, and if not, installs the program.

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -374,6 +374,12 @@ function doDevonCommandAndReturn() {
   fi
 }
 
+function doUpdateMirrors() {
+  local mirrors_dir="${DEVON_IDE_HOME}/mirrors"
+  doDebug "Cloning or updating download mirrors"
+  doGitPullOrClone "${mirrors_dir}" "${DEVON_MIRRORS:-https://github.com/devonfw/ide-mirrors.git}"
+}
+
 # $1: the URL to download
 # $2: the optional, target directory to save to
 # $3: the software to download (e.g. 'java', 'mvn', 'node')
@@ -421,10 +427,8 @@ function doDownload() {
         os="${OSTYPE}"
       fi
     fi
-    local mirrors_dir="${DEVON_IDE_HOME}/mirrors"
-    doDebug "Cloning or updating download mirrors"
-    doGitPullOrClone "${mirrors_dir}" "${DEVON_MIRRORS:-https://github.com/devonfw/ide-mirrors.git}"
-    local mirrors_software_dir="${mirrors_dir}/${software}"
+    doUpdateMirrors
+    local mirrors_software_dir="${DEVON_IDE_HOME}/mirrors/${software}"
     if [ ! -d "${mirrors_software_dir}" ]
     then
       doFail "No mirror is configured at ${mirrors_software_dir}"
@@ -635,7 +639,7 @@ function doGetExtension() {
 #.$@ any number of file paths
 # echos the first of the given paths that does exist
 function doGetFirstExistingPathOrFail() {
-  local message="None of the followin path(s) exists:"
+  local message="None of the following path(s) exists:"
   while [ -n "${1}" ]
   do
     message="${message}\n${1}"
@@ -1568,14 +1572,22 @@ function doGetToolFolderName() {
 function doGetSoftwareVersion() {
   local software="${1}"
   local version_cmd="${2}"
+  local commandlet="${3}"
   local software_folder="${DEVON_IDE_HOME}/software/${software}"
   if [ ! -d "${software_folder}" ]
   then
     software_folder="${DEVON_IDE_HOME}/software/extra/${software}"
     if [ ! -d "${software_folder}" ]
     then
-      #TODO global tools
-      doFail "Software ${software} is not installed.\nUse 'devon ${3} setup' to install."
+      local software_cmd="${commandlet}"
+      if [ "${commandlet}" = "cobigen" ]
+      then
+        software_cmd="cg"
+      fi
+      if ! command -v "${software_cmd}" &> /dev/null
+      then
+        doFail "Software ${software} is not installed.\nUse 'devon ${commandlet} setup' to install."
+      fi
     fi
   fi
   local version_file="${software_folder}/.devon.software.version"

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -462,7 +462,7 @@ function doDownload() {
     # remap architecture
     local mirrors_arch
     local arch_new="${arch}"
-    mirrors_arch="$(doGetFirstExistingPath "${mirrors_override_dir}/arch-mappings" "${mirrors_software_dir}/arch-mappings" "${mirrors_dir}/arch-mappings")"
+    mirrors_arch="$(doGetFirstExistingPath "${mirrors_override_dir}/arch-mappings" "${mirrors_software_dir}/arch-mappings" "${DEVON_IDE_HOME}/mirrors/arch-mappings")"
     if [ -e "${mirrors_arch}" ]
     then
       while IFS="=" read -r key value
@@ -493,7 +493,7 @@ function doDownload() {
     # remap operating system
     local mirrors_os
     local os_new="${os}"
-    mirrors_os="$(doGetFirstExistingPathOrFail "${mirrors_override_dir}/os-mappings" "${mirrors_software_dir}/os-mappings" "${mirrors_dir}/os-mappings")"
+    mirrors_os="$(doGetFirstExistingPathOrFail "${mirrors_override_dir}/os-mappings" "${mirrors_software_dir}/os-mappings" "${DEVON_IDE_HOME}/mirrors/os-mappings")"
     local key
     local value
     while IFS="=" read -r key value
@@ -1592,19 +1592,25 @@ function doGetSoftwareVersion() {
 
 # $1: software
 # $2: selected version
+# $3: commandlet name
 function doSetSoftwareVersion() {
   local software="${1}"
   local version="${2}"
+  local commandlet="${3}"
   if [ -n "${version}" ]
   then
     if [ "${version}" = "latest" ]
     then
+      doUpdateMirrors
       version="$(head -n 1 "${DEVON_IDE_HOME}/mirrors/${software}/available-versions")"
     fi
-    software=$(echo "${software}" | awk '{print toupper($0)}')
-    grep -v "${software}_VERSION" "${DEVON_IDE_HOME}/settings/devon.properties" > "${DEVON_IDE_HOME}/settings/devon.properties.tmp"
-    mv "${DEVON_IDE_HOME}/settings/devon.properties.tmp" "${DEVON_IDE_HOME}/settings/devon.properties"
-    echo "${software}_VERSION=\"${version}\"" >> "${DEVON_IDE_HOME}/settings/devon.properties"
+    local software_version_variable
+    software_version_variable="$(echo "${software}" | awk '{print toupper($0)}')_VERSION"
+    local devon_properties="${DEVON_IDE_HOME}/settings/devon.properties"
+    grep -v "${software_version_variable}" "${devon_properties}" > "${devon_properties}.tmp"
+    mv "${devon_properties}.tmp" "${devon_properties}"
+    echo "${software_version_variable}=\"${version}\"" >> "${devon_properties}"
+    doEchoInteraction "${software_version_variable}=\"${version}\" has been set in ${devon_properties}\nTo install that version call the following command:\ndevon ${commandlet} setup"
   else
     doError "You have to specify the version you want to set."
   fi
@@ -1612,7 +1618,9 @@ function doSetSoftwareVersion() {
 
 # $1: software
 function doListSoftwareVersions() {
-  local versions_path="${DEVON_IDE_HOME}/mirrors/${1}/available-versions"
+  local software="${1}"
+  doUpdateMirrors
+  local versions_path="${DEVON_IDE_HOME}/mirrors/${software}/available-versions"
   if [ ! -f "${versions_path}" ]
   then
     doError "No versions available at ${versions_path}"
@@ -1664,7 +1672,7 @@ function doParseOption() {
         exit
       elif [ "${2}" = "set" ]
       then
-        doSetSoftwareVersion "$(doGetToolFolderName "${0}")" "${3}"
+        doSetSoftwareVersion "$(doGetToolFolderName "${0}")" "${3}" "${0/*\//}"
         exit
       elif [ "${2}" = "get" ] || [ -z "${2}" ]
       then


### PR DESCRIPTION
Small fixes and improvements to changes from #826 and part of #933:
* when extracting `doUpdateMirrors` I also extracted the `mirrors_dir` variable what caused some confusing errors discussed in #933 - see PR #934 that will receive an upstream fix with this PR after merge.
* when `devon «tool» version list` is performed or `devon «tool» version set latest` is performed, the mirrors git needs to be cloned and up-to-date what was missing in #826 
* after `devon «tool» version set «version»` I now output a hint to the user to run setup to actually do the installation