### PR TITLE
#944: Remove cancelled runs from all workflows

### DIFF
--- a/.github/workflows/clean-runs.yml
+++ b/.github/workflows/clean-runs.yml
@@ -1,0 +1,17 @@
+name: Delete cancelled workflow runs
+on:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cancelled workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 0
+          keep_minimum_runs: 0
+          delete_run_by_conclusion_pattern: cancelled


### PR DESCRIPTION
To delete all cancelled workflows, I use [this](https://github.com/Mattraks/delete-workflow-runs) github action in d580866 . The question is: Can we trust this github action or should we implement this action ourselves?