### PR TITLE
#974: Fixed dotnet command for nightly test 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -6,7 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/ide[devonf
 
 WIP: Release with small but important bugfixes:
 
-* TODO: replace me
+* https://github.com/devonfw/ide/issues/974[#974]: Fixed dotnet command
 
 The full list of changes for this release can be found in https://github.com/devonfw/ide/milestone/35?closed=1[milestone 2022.11.002].
 

--- a/scripts/src/main/resources/scripts/command/dotnet
+++ b/scripts/src/main/resources/scripts/command/dotnet
@@ -32,7 +32,7 @@ function doSetup() {
   then
     doDebug "Devon4net template already installed."
   else
-    doRun new -i devon4net.WebApi.Template
+    doRunCommand "'${DOTNET}' new -i devon4net.WebApi.Template"
   fi
 }
 


### PR DESCRIPTION
The nightly test showed us an error after the dotnet installation. While analysing the error, I realised that there is something like a loop so that the github runner comes to `segmentation fault` error.  This PR fixes this bug.

More details can be found in related issue: https://github.com/devonfw/ide/issues/974