### PR TITLE
#887: Temporary fixed vscode nightly test

### DIFF
--- a/scripts/src/test/bash/integration-test-vscode
+++ b/scripts/src/test/bash/integration-test-vscode
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 source "$(dirname "${0}")"/functions-test
+#workaround for nightly-tests
+echo "plugin_active=false" >> settings/vscode/plugins/devonfw-extension-pack.properties
 doCommandTest vscode


### PR DESCRIPTION
This PR fixed the nightly test for vscode. The nightly test failed, because the devonfw-extension-pack plugin was installed automatically and reached the timeout of github actions.

This fix belongs to related issue: https://github.com/devonfw/ide/issues/887

A new issue: [982](https://github.com/devonfw/ide/issues/982) was created to extend the vscode commandlet so that the workaround is no longer necessary.