### PR TITLE
#964: fix aws win-setup to work again

### DIFF
--- a/scripts/src/main/resources/scripts/command/aws
+++ b/scripts/src/main/resources/scripts/command/aws
@@ -52,8 +52,10 @@ function doPackageInstall() {
   if doIsWindows
   then
     doEcho "Installing AWS for Windows..."
-    windows_path_to_package=$(cygpath -w "${path_to_package}")
-    powershell.exe -Command "Start-Process msiexec.exe -verb runas -Wait -ArgumentList '/I ${windows_path_to_package}\aws-*-windows.msi /quiet'"
+    msifilename=$(ls ${path_to_package} | grep ".msi" | head -1)
+    path_to_file=${path_to_package}/${msifilename}
+    windows_path_to_file=$(cygpath -w "${path_to_file}")
+    powershell.exe -Command "Start-Process msiexec.exe -verb runas -Wait -ArgumentList '/i ${windows_path_to_file} /quiet'"
   elif doIsMacOs
   then
     doEcho "Installing AWS for MacOS..."


### PR DESCRIPTION
While looking at issue #964, I stumbled upon a setup problem. On my computer the msi file won't be installed. 
It turned out, that `powershell.exe -Command "Start-Process msiexec.exe -verb runas -Wait -ArgumentList '/I ${windows_path_to_package}\aws-*-windows.msi /quiet'"` won't work on my computer, because the asterix sign  `*`  in `aws-*-windows.msi` won't be replaced by the version number. There may be another way to solve, like with `\"\"` instead of `''`, but I liked Carstens way of using ${windows_path_to_package} as this also worked for me, so I only modified it a bit. 