### PR TITLE
#982: Add recommendation feature and clean setup option to vscode

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/ide[devonf
 
 Release with small but important bugfixes:
 
+* https://github.com/devonfw/ide/issues/982[#982]: Add recommendation feature and clean setup option to vscode
 * https://github.com/devonfw/ide/issues/966[#966]: npm detection not reliable and redundant
 * https://github.com/devonfw/ide/issues/954[#954]: First install removes all folders from user path
 * https://github.com/devonfw/ide/issues/956[#956]: no matches found error if software folder missing

--- a/documentation/vscode.asciidoc
+++ b/documentation/vscode.asciidoc
@@ -22,6 +22,7 @@ You may also supply additional arguments as `devon vscode «args»`. These are e
 |`ws-re[verse]`  |reverse merge changes from workspace into settings
 |`ws-reverse-add`|reverse merge adding new properties
 |`create-script` |create launch script for this IDE, your current workspace and your OS
+|`clean-setup`   |clean VSCode setup without plugins and recommendations
 |=======================
 
 
@@ -42,7 +43,7 @@ The variables are defined as following:
 
 In general you should try to stick with the configuration pre-defined by your project. But some plugins may be considered as personal flavor and are typically not predefined by the project config. Such plugins should be shipped with your link:settings.asciidoc[settings] as described above with `plugin_active=false` allowing you to easily install it manually. Surely, you can easily add plugins via the UI of VS code. However, be aware that some plugins may collect sensitive data or could introduce other vulnerabilities. So consider the governance of your project and talk to your technical lead before installing additional plugins that are not pre-defined in your link:settings.asciidoc[settings].
 
-As maintainer of the link:settings.asciidoc[settings] for your project you should avoid to ship too many plugins that may waste resources but are not used by every developer. By configuring additional plugins with `plugin_active=false` you can give your developers the freedom to install some additional plugins easily.
+As maintainer of the link:settings.asciidoc[settings] for your project you should avoid to ship too many plugins that may waste resources but are not used by every developer. By configuring additional plugins with `plugin_active=false` you can give your developers the freedom to install some additional plugins easily. In addition, deactivated plugins are recommended to the user by an existing link:https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions[feature] of VS Code via prompt.
 
 === cleaning plugins on update
 

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -55,12 +55,12 @@ function doAddPlugins() {
     then
       plugin_id=""
       plugin_active="true"
-      plugin_recommend="true"
+      plugin_recommended="true"
       doLoadProperties "${file}"
       if [ -z "${plugin_id}" ]
       then
         doWarning "Invalid vscode plugin config: ${file}"
-      elif [ "${plugin_recommend}" = "true" ]
+      elif [ "${plugin_recommended}" = "true" ]
       then
         local IFS=,
         pluginsToRecommend+=("\"${plugin_id}\"")

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -143,7 +143,7 @@ function doAddRecommendations() {
   local extensions="${WORKSPACE_PATH}/.vscode/extensions.json"
   if [ -f "${extensions}" ]
   then
-    rm -fR "${extensions}"
+    rm "${extensions}"
     echo "{\"recommendations\":[${1}]}" >> "${extensions}"
   else
     echo "{\"recommendations\":[${1}]}" >> "${extensions}"

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -164,7 +164,7 @@ then
   echo " ws-re[verse]                   reverse merge changes from workspace into settings"
   echo " ws-reverse-add                 reverse merge adding new properties"
   echo " create-script                  create vscode-${WORKSPACE} script if not already exists"
-  echo " clean-setup                    clean setup VSCode without plugins and recommendations"
+  echo " clean-setup                    clean VSCode setup without plugins and recommendations"
   exit
 fi
 if [ -z "${1}" ]

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -158,13 +158,13 @@ then
   echo "Arguments:"
   echo " --all                          if provided as first arg then to command will be invoked for each workspace"
   echo " setup                          setup VSCode (install or update)"
-  echo " clean-setup                    clean setup VSCode without plugins and recommendations"
   echo " add-plugin «id»                install an additional plugin (extension)"
   echo " run | start                    launch VSCode IDE (default if no argument is given)"
   echo " ws-up[date]                    update VSCode workspace"
   echo " ws-re[verse]                   reverse merge changes from workspace into settings"
   echo " ws-reverse-add                 reverse merge adding new properties"
   echo " create-script                  create vscode-${WORKSPACE} script if not already exists"
+  echo " clean-setup                    clean setup VSCode without plugins and recommendations"
   exit
 fi
 if [ -z "${1}" ]

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -25,7 +25,7 @@ cd "${DEVON_IDE_HOME}" || exit 255
 
 function doSetup() {
   doInstall "vscode" "${VSCODE_VERSION}" "${1}"
-  if [ "${?}" = 0 ]
+  if [ "${?}" = 0 ] && [ "${1}" != "clean" ] 
   then
     cleanupPlugins
     doAddPlugins
@@ -48,16 +48,22 @@ function cleanupPlugins() {
 function doAddPlugins() {
   local file
   local pluginsToInstall=()
+  local pluginsToRecommend=()
   for file in "${SETTINGS_PATH}"/vscode/plugins/*.properties
   do
     if [ -f "${file}" ]
     then
       plugin_id=""
       plugin_active="true"
+      plugin_recommend="true"
       doLoadProperties "${file}"
       if [ -z "${plugin_id}" ]
       then
         doWarning "Invalid vscode plugin config: ${file}"
+      elif [ "${plugin_recommend}" = "true" ]
+      then
+        local IFS=,
+        pluginsToRecommend+=("\"${plugin_id}\"")
       elif [ "${plugin_active}" = "true" ]
       then
         pluginsToInstall+=("${plugin_id}")
@@ -67,6 +73,10 @@ function doAddPlugins() {
   if [ "${#pluginsToInstall}" -gt 0 ]
   then
     doAddPlugin "${pluginsToInstall[@]}"
+  fi
+  if [ "${#pluginsToRecommend}" -gt 0 ]
+  then
+    doAddRecommendations "${pluginsToRecommend[*]}"
   fi
 }
 
@@ -126,6 +136,11 @@ function doStartVsCode() {
   doRunVsCode "${WORKSPACE_PATH}"
 }
 
+function doAddRecommendations() {
+  doEcho "add recommendations..."
+  echo "{\"recommendations\":[${1}]}" > "${WORKSPACE_PATH}/.vscode/extensions.json"
+}
+  
 # CLI
 if [ "${1}" = "-h" ] || [ "${1}" = "help" ]
 then
@@ -134,6 +149,7 @@ then
   echo "Arguments:"
   echo " --all                          if provided as first arg then to command will be invoked for each workspace"
   echo " setup                          setup VSCode (install or update)"
+  echo " setup clean                    setup VSCode without plugins and recommendations"
   echo " add-plugin «id»                install an additional plugin (extension)"
   echo " run | start                    launch VSCode IDE (default if no argument is given)"
   echo " ws-up[date]                    update VSCode workspace"

--- a/scripts/src/main/resources/scripts/command/vscode
+++ b/scripts/src/main/resources/scripts/command/vscode
@@ -25,11 +25,15 @@ cd "${DEVON_IDE_HOME}" || exit 255
 
 function doSetup() {
   doInstall "vscode" "${VSCODE_VERSION}" "${1}"
-  if [ "${?}" = 0 ] && [ "${1}" != "clean" ] 
+  if [ "${?}" = 0 ]
   then
     cleanupPlugins
     doAddPlugins
   fi
+}
+
+function doCleanSetup() {
+  doInstall "vscode" "${VSCODE_VERSION}" "${1}"
 }
 
 function cleanupPlugins() {
@@ -55,18 +59,15 @@ function doAddPlugins() {
     then
       plugin_id=""
       plugin_active="true"
-      plugin_recommended="true"
       doLoadProperties "${file}"
       if [ -z "${plugin_id}" ]
       then
         doWarning "Invalid vscode plugin config: ${file}"
-      elif [ "${plugin_recommended}" = "true" ]
-      then
-        local IFS=,
-        pluginsToRecommend+=("\"${plugin_id}\"")
       elif [ "${plugin_active}" = "true" ]
       then
         pluginsToInstall+=("${plugin_id}")
+      else    
+        pluginsToRecommend+=("\"${plugin_id}\"")
       fi
     fi
   done
@@ -76,6 +77,7 @@ function doAddPlugins() {
   fi
   if [ "${#pluginsToRecommend}" -gt 0 ]
   then
+    local IFS=,
     doAddRecommendations "${pluginsToRecommend[*]}"
   fi
 }
@@ -138,7 +140,14 @@ function doStartVsCode() {
 
 function doAddRecommendations() {
   doEcho "add recommendations..."
-  echo "{\"recommendations\":[${1}]}" > "${WORKSPACE_PATH}/.vscode/extensions.json"
+  local extensions="${WORKSPACE_PATH}/.vscode/extensions.json"
+  if [ -f "${extensions}" ]
+  then
+    rm -fR "${extensions}"
+    echo "{\"recommendations\":[${1}]}" >> "${extensions}"
+  else
+    echo "{\"recommendations\":[${1}]}" >> "${extensions}"
+  fi
 }
   
 # CLI
@@ -149,7 +158,7 @@ then
   echo "Arguments:"
   echo " --all                          if provided as first arg then to command will be invoked for each workspace"
   echo " setup                          setup VSCode (install or update)"
-  echo " setup clean                    setup VSCode without plugins and recommendations"
+  echo " clean-setup                    clean setup VSCode without plugins and recommendations"
   echo " add-plugin «id»                install an additional plugin (extension)"
   echo " run | start                    launch VSCode IDE (default if no argument is given)"
   echo " ws-up[date]                    update VSCode workspace"
@@ -196,6 +205,11 @@ do
     shift
     doAddPlugin "${@}"
     exit ${?}
+  elif [ "${1}" = "clean-setup" ]
+  then
+    doCleanSetup "${2}"
+    doStartVsCode
+    exit
   else
     doFail "Undefined argument: ${1}"
   fi


### PR DESCRIPTION
This feature adds deactivated plugins as "recommended" plugins for vscode, after vscode is installed. See [here](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions).

In addition, there is a new option to install vscode without plugins and recommendations in a clean way with `devon vscode clean-setup`.

Link to related issue: https://github.com/devonfw/ide/issues/982