### PR TITLE
#939: extending test functions doc to check for invocation of undeclared functions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,11 +1,12 @@
 = Changelog of devonfw-ide
 
 This file documents all notable changes to https://github.com/devonfw/ide[devonfw-ide].
-
+*
 == 2022.11.002
 
 Release with small but important bugfixes:
 
+* https://github.com/devonfw/ide/issues/939[#939]: Consider extending test-functions-doc with invocation of undeclared functions
 * https://github.com/devonfw/ide/issues/966[#966]: npm detection not reliable and redundant
 * https://github.com/devonfw/ide/issues/954[#954]: First install removes all folders from user path
 * https://github.com/devonfw/ide/issues/956[#956]: no matches found error if software folder missing

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,8 +7,6 @@ This file documents all notable changes to https://github.com/devonfw/ide[devonf
 Release with new features and bugfixes:
 * https://github.com/devonfw/ide/issues/939[#939]: Consider extending test-functions-doc with invocation of undeclared functions
 
-* TODO
-
 The full list of changes for this release can be found in https://github.com/devonfw/ide/milestone/37?closed=1[milestone 2022.12.001].
 
 == 2022.11.002

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,6 +1,6 @@
 = Changelog of devonfw-ide
 
-
+This file documents all notable changes to https://github.com/devonfw/ide[devonfw-ide].
 
 == 2022.12.001
 
@@ -9,7 +9,6 @@ Release with new features and bugfixes:
 * TODO
 
 The full list of changes for this release can be found in https://github.com/devonfw/ide/milestone/37?closed=1[milestone 2022.12.001].
-
 
 == 2022.11.002
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -5,6 +5,7 @@ This file documents all notable changes to https://github.com/devonfw/ide[devonf
 == 2022.12.001
 
 Release with new features and bugfixes:
+* https://github.com/devonfw/ide/issues/939[#939]: Consider extending test-functions-doc with invocation of undeclared functions
 
 * TODO
 
@@ -14,7 +15,6 @@ The full list of changes for this release can be found in https://github.com/dev
 
 Release with small but important bugfixes:
 
-* https://github.com/devonfw/ide/issues/939[#939]: Consider extending test-functions-doc with invocation of undeclared functions
 * https://github.com/devonfw/ide/issues/966[#966]: npm detection not reliable and redundant
 * https://github.com/devonfw/ide/issues/954[#954]: First install removes all folders from user path
 * https://github.com/devonfw/ide/issues/956[#956]: no matches found error if software folder missing

--- a/scripts/src/main/resources/scripts/command/gcviewer
+++ b/scripts/src/main/resources/scripts/command/gcviewer
@@ -32,7 +32,7 @@ function doStart() {
   "${GCVIEWER_HOME}/gcviewer"
 }
 
-doCreateGCViewerScript() {
+function doCreateGCViewerScript() {
   echo -e "#!/usr/bin/env bash\ncd \${0%/*}\njava -jar gcviewer*.jar&" > "${GCVIEWER_HOME}/gcviewer"
   chmod a+x "${GCVIEWER_HOME}/gcviewer"
 }

--- a/scripts/src/test/bash/test-functions-doc
+++ b/scripts/src/test/bash/test-functions-doc
@@ -1,12 +1,17 @@
 #!/bin/bash
 
 SCRIPTS_PATH="../../../../scripts/src/main/resources/scripts"
-( set -o pipefail; grep "function " "${SCRIPTS_PATH}/functions" "${SCRIPTS_PATH}/functions-core" | sed 's/.*function //' | sed 's/() {//' | sort -u > functions.list ) || exit 1
-( set -o pipefail; grep "=== " "../../../../documentation/functions.asciidoc"  | sed 's/=== //' | sort -u > functions.adoc.list ) || exit 1
+(
+  set -o pipefail
+  grep "function " "${SCRIPTS_PATH}/functions" "${SCRIPTS_PATH}/functions-core" | sed 's/.*function //' | sed 's/() {//' | sort -u >functions.list
+) || exit 1
+(
+  set -o pipefail
+  grep "=== " "../../../../documentation/functions.asciidoc" | sed 's/=== //' | sort -u >functions.adoc.list
+) || exit 1
 
 diff functions.list functions.adoc.list
-if [ "$?" = 0 ]
-then
+if [ "$?" = 0 ]; then
   echo "Documentation of functions and function declarations are in sync."
   echo "Awesome!"
 else
@@ -14,3 +19,13 @@ else
   echo "Please keep function documentation and declarations in sync!"
   exit 1
 fi
+#grep all unique strings in the SCRIPTS_PATH/functions file that follow the pattern do[A-Z][a-zA-Z]*. Then check for each if there is a corresponding function in the SCRIPTS_PATH/functions file
+(
+  set -o pipefail
+  grep -o -E "do[A-Z][a-zA-Z]*" $SCRIPTS_PATH/functions | sort | uniq |
+    while read -r line; do
+      if ! grep -q "$line" "./functions.list"; then
+        echo "Missing decleration for function $line"
+      fi
+    done
+) || exit 1

--- a/scripts/src/test/bash/test-functions-doc
+++ b/scripts/src/test/bash/test-functions-doc
@@ -21,17 +21,17 @@ else
   exit 1
 fi
 
-#For every file in SCRIPTS_PATH/command, check for functions that follow the pattern do[A-Z][a-zA-Z]*. 
+#For every file in SCRIPTS_PATH/command and SCRIPTS_PATH/function and SCRIPTS_PATH/function-core, check for functions that follow the pattern do[A-Z][a-zA-Z]*. 
 #Then check if there is a corresponding function declared in the same file or in functions.list file
 #which contains every function declared in functions and functions-core files.
 
-for file in "$SCRIPTS_PATH"/command/*; do
+for file in "$SCRIPTS_PATH"/command/* "$SCRIPTS_PATH/functions" "$SCRIPTS_PATH/functions-core"; do
   (
     set -o pipefail
     grep -o -E "do[A-Z][a-zA-Z]*" "$file" | sort | uniq |
-      while read -r line; do
-        if ! grep -q "function $line" "$file" && ! grep -q "$line" "$TEST_PATH/functions.list"; then
-          echo "Function $line is neither declared in $file nor in Devon Functions Files!"
+      while read -r functionName; do
+        if ! grep -q "function $functionName" "$file" && ! grep -q "$functionName" "$TEST_PATH/functions.list"; then
+          echo "Function $functionName is neither declared in $file nor in Devon Functions Files!"
         fi
       done
   ) || exit 1

--- a/scripts/src/test/bash/test-functions-doc
+++ b/scripts/src/test/bash/test-functions-doc
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 SCRIPTS_PATH="../../../../scripts/src/main/resources/scripts"
+TEST_PATH="../../../../scripts/src/test/bash"
 (
   set -o pipefail
   grep "function " "${SCRIPTS_PATH}/functions" "${SCRIPTS_PATH}/functions-core" | sed 's/.*function //' | sed 's/() {//' | sort -u >functions.list
@@ -19,13 +20,19 @@ else
   echo "Please keep function documentation and declarations in sync!"
   exit 1
 fi
-#grep all unique strings in the SCRIPTS_PATH/functions file that follow the pattern do[A-Z][a-zA-Z]*. Then check for each if there is a corresponding function in the SCRIPTS_PATH/functions file
-(
-  set -o pipefail
-  grep -o -E "do[A-Z][a-zA-Z]*" $SCRIPTS_PATH/functions | sort | uniq |
-    while read -r line; do
-      if ! grep -q "$line" "./functions.list"; then
-        echo "Missing decleration for function $line"
-      fi
-    done
-) || exit 1
+
+#For every file in SCRIPTS_PATH/command, check for functions that follow the pattern do[A-Z][a-zA-Z]*. 
+#Then check if there is a corresponding function declared in the same file or in functions.list file
+#which contains every function declared in functions and functions-core files.
+
+for file in "$SCRIPTS_PATH"/command/*; do
+  (
+    set -o pipefail
+    grep -o -E "do[A-Z][a-zA-Z]*" "$file" | sort | uniq |
+      while read -r line; do
+        if ! grep -q "function $line" "$file" && ! grep -q "$line" "$TEST_PATH/functions.list"; then
+          echo "Function $line is neither declared in $file nor in Devon Functions Files!"
+        fi
+      done
+  ) || exit 1
+done


### PR DESCRIPTION
Functions in commandlets are now checked to have a decleration either in the same file or in one of the devon function files!
Tested it and it already found one function that missed the "function" keyword. I didn't even know before that you could define functions without the function keyword 😄 

![image](https://user-images.githubusercontent.com/102921542/204282921-2d340807-1ccb-46b4-86f0-14a898aa2b99.png)
![image](https://user-images.githubusercontent.com/102921542/204282962-af8343bc-4c59-4a91-9131-68c0cd42f2fc.png)

