### PR TITLE
#996: Disable Python Integration Test for MacOS and Ubuntu

### DIFF
--- a/.github/workflows/test-macos-light.yml
+++ b/.github/workflows/test-macos-light.yml
@@ -1,6 +1,6 @@
 name: Integration Test MacOS
 on: 
-  workflow_dispatch
+  push
 jobs:
   test:
     name: Integration test MacOS

--- a/.github/workflows/test-macos-light.yml
+++ b/.github/workflows/test-macos-light.yml
@@ -5,8 +5,6 @@ jobs:
   test:
     name: Integration test MacOS
     runs-on: macos-latest
-    needs: verify_commit
-    if: ${{ needs.verify_commit.outputs.RUN_BUILD == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-macos-light.yml
+++ b/.github/workflows/test-macos-light.yml
@@ -1,0 +1,24 @@
+name: Integration Test MacOS
+on: 
+  workflow_dispatch
+jobs:
+  test:
+    name: Integration test MacOS
+    runs-on: macos-latest
+    needs: verify_commit
+    if: ${{ needs.verify_commit.outputs.RUN_BUILD == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Set up shellcheck
+        run: brew install shellcheck
+      - name: Build project with Maven
+        run: |
+          export INTEGRATION_TEST=true
+          mvn -B -ntp install

--- a/.github/workflows/test-ubuntu-light.yml
+++ b/.github/workflows/test-ubuntu-light.yml
@@ -1,0 +1,20 @@
+name: Integration Test Ubuntu
+on: 
+  workflow_dispatch
+jobs:
+  test:
+    name: Integration test Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Build project with Maven
+        run: |
+          export INTEGRATION_TEST=true
+          mvn -B -ntp install

--- a/.github/workflows/test-windows-light.yml
+++ b/.github/workflows/test-windows-light.yml
@@ -1,0 +1,25 @@
+name: Integration Test Windows
+on:
+  workflow_dispatch
+jobs:
+  test:
+    name: Integration test Windows
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Set up shellcheck
+        run: choco install shellcheck
+      - name: Build project with Maven
+        run: |
+          export INTEGRATION_TEST=true
+          mvn -B -ntp install

--- a/scripts/src/test/bash/functions-test
+++ b/scripts/src/test/bash/functions-test
@@ -20,3 +20,19 @@ function doWarning() {
 function doError() {
   echo -e "\033[91m${1}\033[39m"
 }
+
+function doIsMacOs() {
+  if [ "${OSTYPE:0:6}" = "darwin" ]
+  then
+    return
+  fi
+  return 255
+}
+
+function doIsWindows() {
+  if [ "${OSTYPE}" = "cygwin" ] || [ "${OSTYPE}" = "msys" ]
+  then
+    return
+  fi
+  return 255
+}

--- a/scripts/src/test/bash/integration-test-az
+++ b/scripts/src/test/bash/integration-test-az
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 source "$(dirname "${0}")"/functions-test
-doCommandTest az
+if doIsWindows
+then
+  doCommandTest az
+else
+  echo "The integration-test for az is disabled for MacOS and Linux systems"
+  exit 0
+fi

--- a/scripts/src/test/bash/integration-test-az
+++ b/scripts/src/test/bash/integration-test-az
@@ -5,6 +5,6 @@ if doIsWindows
 then
   doCommandTest az
 else
-  echo "The integration-test for az is disabled for MacOS and Linux systems"
+  echo "The integration-test for az is currently disabled for MacOS and Linux systems"
   exit 0
 fi

--- a/scripts/src/test/bash/integration-test-pip
+++ b/scripts/src/test/bash/integration-test-pip
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 source "$(dirname "${0}")"/functions-test
-doCommandTest pip
+if doIsWindows
+then
+  doCommandTest pip
+else
+  echo "The integration-test for pip is currently disabled for MacOS and Linux systems"
+  exit 0
+fi

--- a/scripts/src/test/bash/integration-test-python
+++ b/scripts/src/test/bash/integration-test-python
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 source "$(dirname "${0}")"/functions-test
-
 if doIsWindows
 then
   doCommandTest python
 else
-  echo "The integration-test for Python is disabled for MacOS and Linux systems"
+  echo "The integration-test for python is currently disabled for MacOS and Linux systems"
   exit 0
 fi

--- a/scripts/src/test/bash/integration-test-python
+++ b/scripts/src/test/bash/integration-test-python
@@ -1,4 +1,11 @@
 #!/bin/bash
 
 source "$(dirname "${0}")"/functions-test
-doCommandTest python
+
+if doIsWindows
+then
+  doCommandTest python
+else
+  echo "The integration-test for Python is disabled for MacOS and Linux systems"
+  exit 0
+fi


### PR DESCRIPTION
Currently Python is only implemented for Windows without errors. While we are not find a better solution to handle Python on MacOS and Linux systems.