### PR TITLE
#1005: update devon.bat to show bash error

### DIFF
--- a/scripts/src/main/resources/scripts/devon.bat
+++ b/scripts/src/main/resources/scripts/devon.bat
@@ -65,6 +65,8 @@ if exist "%GIT_HOME%\bin\bash.exe" (
   goto :bash_detected
 )
 
+echo %_fBYellow%WARNING: Git-bash is required but was not found at GIT_HOME=%GIT_HOME%.%_RESET%
+
 rem If bash in GitForWindows could not be found search Cygwin Installation - prefer user over machine result
 for %%H in ( HKEY_LOCAL_MACHINE HKEY_CURRENT_USER ) do for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "%%H\Software\Cygwin\setup" /v "rootdir" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set CYGWIN_HOME=%%P
 

--- a/scripts/src/main/resources/scripts/devon.bat
+++ b/scripts/src/main/resources/scripts/devon.bat
@@ -14,7 +14,7 @@ Set _fBGreen=[92m
 Set _fBRed=[91m
 Set _RESET=[0m
 
-rem Auto-install oursevles...
+rem Auto-install ourselves...
 if not exist "%USERPROFILE%\scripts" (
   md "%USERPROFILE%\scripts"
 )
@@ -55,6 +55,7 @@ if "%1%" == "" (
   goto :setup_env
 )
 
+:git_installation
 rem Search GitForWindows Installation - prefer user over machine result
 for %%H in ( HKEY_LOCAL_MACHINE HKEY_CURRENT_USER ) do for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "%%H\Software\GitForWindows" /v "InstallPath" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set GIT_HOME=%%P
 
@@ -75,16 +76,17 @@ if exist "%CYGWIN_HOME%\bin\bash.exe" (
 
 rem If bash can not be autodetected allow the user to configure bash via BASH_HOME environment variable as fallback
 
-if exists "%BASH_HOME%\bin\bash.exe" (
+if exist "%BASH_HOME%\bin\bash.exe" (
   set "BASH=%BASH_HOME%\bin\bash.exe"
   set "HOME=%USERPROFILE%"
   goto :bash_detected
 )
 echo:
 echo %_fBYellow%*** ATTENTION ***%_RESET%
-echo %_fBRed%Bash has not been found on your system!%_RESET%
-echo %_fBRed%Please install git for windows on your system.%_RESET%
+echo %_fBRed%ERROR: Could not find bash. It seems git for windows is not installed on your machine%_RESET%
+echo %_fBRed%Please download and install git for windows from the following URL and after that rerun devonfw-ide setup:%_RESET%
 echo %_fBRed%https://git-scm.com/download/win%_RESET%
+pause
 goto :eof
 
 :bash_detected
@@ -119,6 +121,7 @@ if not "%DEVON_PATH%" == "" (
   set "PATH=%DEVON_PATH%"
   set "DEVON_PATH="
 )
+pause
 goto :eof
 
 :setup_env
@@ -130,11 +133,12 @@ if exist scripts\environment-project.bat (
   call scripts\environment-project.bat
   echo devonfw-ide environment variables have been set for %CD% in workspace %WORKSPACE%
   popd
-  goto :eof
+  goto :git_installation
 )
 if "%CD%" == "%CD:~0,3%" (
   popd
   echo You are not inside a devon IDE installation: %CD%
+  pause
   goto :eof
 )
 set last_folder=%folder%
@@ -146,7 +150,7 @@ if "%folder%" == "workspaces" (
 )
 cd ..  
 goto :iterate_backwards
-
+pause
 goto :eof
 
 rem subroutine to print version


### PR DESCRIPTION
- add pause before goto :eof to prevent terminal from closing immediately (if git bash is not installed)
- add new subroutine called "git_installation". This allows git for windows installation conditions to be executed/checked. 