### PR TITLE
#1004: GCloud CLI integration for windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -2,7 +2,7 @@
 
 This file documents all notable changes to https://github.com/devonfw/ide[devonfw-ide].
 
-== 2022.12.002
+== 2023.01.001
 
 Release with new features and bugfixes:
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -2,6 +2,12 @@
 
 This file documents all notable changes to https://github.com/devonfw/ide[devonfw-ide].
 
+== 2022.12.002
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/ide/issues/1004[#1004]: GCloud CLI integration for windows
+
 == 2022.12.001
 
 Release with new features and bugfixes:

--- a/documentation/LICENSE.asciidoc
+++ b/documentation/LICENSE.asciidoc
@@ -68,6 +68,7 @@ The following table shows the components that may be used. The column `inclusion
 |https://github.com/openshift/oc[OpenShiftCLI]|Optional|https://github.com/openshift/oc/blob/master/LICENSE[ASL 2.0]
 |https://github.com/cli/cli/[GitHubCLI]|Optional|https://github.com/cli/cli/blob/trunk/LICENSE[MIT]
 |https://quarkus.io/guides/cli-tooling[QuarkusCLI]|Optional|https://github.com/quarkusio/quarkus/blob/main/LICENSE.txt[ASL 2.0]
+|https://cloud.google.com/sdk/gcloud[GCloudCLI]|Optional|https://github.com/twistedpair/google-cloud-sdk/blob/master/google-cloud-sdk/LICENSE[ASL 2.0]
 |=======================
 
 == Apache Software License - Version 2.0

--- a/documentation/cli.asciidoc
+++ b/documentation/cli.asciidoc
@@ -57,6 +57,7 @@ The following commandlets are currently available:
 * link:docker.asciidoc[docker]
 * link:dotnet.asciidoc[dotnet]
 * link:eclipse.asciidoc[eclipse]
+* link:gcloud.asciidoc[gcloud]
 * link:gcviewer.asciidoc[gcviewer]
 * link:gh.asciidoc[gh]
 * link:graalvm.asciidoc[graalvm]

--- a/documentation/devonfw-ide-usage.asciidoc
+++ b/documentation/devonfw-ide-usage.asciidoc
@@ -28,6 +28,8 @@ include::dotnet.asciidoc[leveloffset=3]
 
 include::eclipse.asciidoc[leveloffset=3]
 
+include::gcloud.asciidoc[leveloffset=3]
+
 include::gcviewer.asciidoc[leveloffset=3]
 
 include::gh.asciidoc[leveloffset=3]

--- a/documentation/gcloud.asciidoc
+++ b/documentation/gcloud.asciidoc
@@ -1,0 +1,15 @@
+:toc:
+toc::[]
+
+= gcloud
+
+The gcloud commandlet allows to install and use https://cloud.google.com/sdk/gcloud[gcloud cli].
+
+The arguments (`devon gcloud «args»`) are explained by the following table:
+
+.Usage of `devon gcloud`
+[options="header"]
+|=======================
+|*Argument(s)*    |*Meaning*
+|`setup`          |install gcloud cli on your machine.
+|=======================

--- a/documentation/scripts.asciidoc
+++ b/documentation/scripts.asciidoc
@@ -15,6 +15,7 @@ This directory is the heart of the `devonfw-ide` and contains the required link:
 │  ├── link:docker.asciidoc[docker]
 │  ├── link:dotnet.asciidoc[dotnet]
 │  ├── link:eclipse.asciidoc[eclipse]
+│  ├── link:gcloud.asciidoc[gcloud]
 │  ├── link:gcviewer.asciidoc[gcviewer]
 │  ├── link:gh.asciidoc[gh]
 │  ├── link:graalvm.asciidoc[graalvm]

--- a/scripts/src/main/resources/scripts/command/gcloud
+++ b/scripts/src/main/resources/scripts/command/gcloud
@@ -10,11 +10,10 @@ then
   exit
 fi
 
-GCLOUD_HOME="${DEVON_IDE_HOME}/software/gcloud"
-TOOL_VERSION_COMMAND="${GCLOUD_HOME}/bin/gcloud.cmd --version"
-
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
+GCLOUD_HOME="${DEVON_IDE_HOME}/software/gcloud"
+TOOL_VERSION_COMMAND="${GCLOUD_HOME}/bin/gcloud.cmd --version"
 # shellcheck source=scripts/commandlet-cli
 source "$(dirname "${0}")"/../commandlet-cli
 
@@ -44,21 +43,13 @@ function doRun() {
 
 function doSetup() {
   doSetRun
+  doConfig
   if doIsWindows
   then
     doInstall "gcloud" "${GCLOUD_VERSION}" "${1}" "" "${GCLOUD_HOME}"
     ERR="${?}"
   else
     doEchoAttention "GCloud is currently not supported for your operation system."
-  fi
-  if [ "${ERR}" = 0 ]
-  then
-    doConfig
-    if [ "${1}" != "silent" ] && ! doIsQuiet
-    then
-      TOOL_VERSION_COMMAND="${GCLOUD_RUN} --version"
-      doRunCommand "${TOOL_VERSION_COMMAND}" "verify installation of gcloud"
-    fi
   fi
 }
 

--- a/scripts/src/main/resources/scripts/command/gcloud
+++ b/scripts/src/main/resources/scripts/command/gcloud
@@ -13,7 +13,7 @@ fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 GCLOUD_HOME="${DEVON_IDE_HOME}/software/gcloud"
-TOOL_VERSION_COMMAND="${GCLOUD_HOME}/bin/gcloud.cmd --version"
+TOOL_VERSION_COMMAND="${GCLOUD_HOME}/bin/gcloud --version"
 # shellcheck source=scripts/commandlet-cli
 source "$(dirname "${0}")"/../commandlet-cli
 
@@ -28,26 +28,32 @@ function doConfig() {
   fi
 }
 
-function doSetRun() {
+# the path of gcloud modules must be added to python's sys.path via .pth file
+function doSetPth() {
+  local wsl_path="${GCLOUD_HOME}/lib"
+  local win_path="$(cygpath -w ${wsl_path})"
+  local pth_file="${DEVON_IDE_HOME}/software/python/ext_modules.pth"
   if doIsWindows
   then
-    GCLOUD_RUN="${GCLOUD_HOME}/bin/gcloud.cmd"
-    # toDo: add other OS's after Python has been fixed for them
+    if ! grep -Fq "${win_path}" "${pth_file}"
+    then
+      echo -e "\n${win_path}" >> "${pth_file}"
+    fi
   fi
 }
 
 function doRun() {
   doSetup silent
-  doRunCommand "${GCLOUD_RUN} ${*}"
+  doRunCommand "${GCLOUD_HOME}/bin/gcloud ${*}"
 }
 
 function doSetup() {
-  doSetRun
+  doDevonCommand python setup silent
+  doSetPth
   doConfig
   if doIsWindows
   then
     doInstall "gcloud" "${GCLOUD_VERSION}" "${1}" "" "${GCLOUD_HOME}"
-    ERR="${?}"
   else
     doEchoAttention "GCloud is currently not supported for your operation system."
   fi

--- a/scripts/src/main/resources/scripts/command/gcloud
+++ b/scripts/src/main/resources/scripts/command/gcloud
@@ -30,12 +30,12 @@ function doConfig() {
 
 # the path of gcloud modules must be added to python's sys.path via .pth file
 function doSetPth() {
-  local wsl_path="${GCLOUD_HOME}/lib"
+  local lib_path="${GCLOUD_HOME}/lib"
   local win_path
   local pth_file="${DEVON_IDE_HOME}/software/python/ext_modules.pth"
   if doIsWindows
   then
-    win_path="$(cygpath -w "${wsl_path}")"
+    win_path="$(cygpath -w "${lib_path}")"
     if ! grep -Fq "${win_path}" "${pth_file}" &> /dev/null
     then
       echo -e "\n${win_path}" >> "${pth_file}"

--- a/scripts/src/main/resources/scripts/command/gcloud
+++ b/scripts/src/main/resources/scripts/command/gcloud
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# autocompletion list
+if [ "${1}" = "shortlist" ]
+then
+  if [ -z "${2}" ]
+  then
+    echo "setup version help"
+  fi
+  exit
+fi
+
+GCLOUD_HOME="${DEVON_IDE_HOME}/software/gcloud"
+TOOL_VERSION_COMMAND="${GCLOUD_HOME}/bin/gcloud.cmd --version"
+
+# shellcheck source=scripts/functions
+source "$(dirname "${0}")"/../functions
+# shellcheck source=scripts/commandlet-cli
+source "$(dirname "${0}")"/../commandlet-cli
+
+function doConfig() {
+  local gcloud_config_files="${DEVON_IDE_HOME}/conf/.gcloud"
+  local gcloud_config_export="export CLOUDSDK_CONFIG=${gcloud_config_files}"
+  if ! grep -q "${gcloud_config_export}" "${DEVON_IDE_HOME}/conf/devon.properties"
+  then
+    doRunCommand "${gcloud_config_export}"
+    echo -e "\n${gcloud_config_export}" >> "${DEVON_IDE_HOME}/conf/devon.properties"
+    doEcho "Location of GClouds's configuration files is set to ${gcloud_config_files}"
+  fi
+}
+
+function doSetRun() {
+  if doIsWindows
+  then
+    GCLOUD_RUN="${GCLOUD_HOME}/bin/gcloud.cmd"
+    # toDo: add other OS's after Python has been fixed for them
+  fi
+}
+
+function doRun() {
+  doSetup silent
+  doRunCommand "${GCLOUD_RUN} ${*}"
+}
+
+function doSetup() {
+  doSetRun
+  if doIsWindows
+  then
+    doInstall "gcloud" "${GCLOUD_VERSION}" "${1}" "" "${GCLOUD_HOME}"
+    ERR="${?}"
+  else
+    doEchoAttention "GCloud is currently not supported for your operation system."
+  fi
+  if [ "${ERR}" = 0 ]
+  then
+    doConfig
+    if [ "${1}" != "silent" ] && ! doIsQuiet
+    then
+      TOOL_VERSION_COMMAND="${GCLOUD_RUN} --version"
+      doRunCommand "${TOOL_VERSION_COMMAND}" "verify installation of gcloud"
+    fi
+  fi
+}
+
+# CLI
+case ${1} in
+"help" | "-h")
+  echo "Setup or run GCloud CLI (command-line interface for Google Cloud Service)."
+  echo
+  echo "Arguments:"
+  echo " setup                          install gcloud on your machine."
+  echo " «args»                         call gcloud with the specified arguments. Call gcloud --help for details or use gcloud directly as preferred."
+  echo
+;;
+"setup" | "s" | "")
+  doSetup "${2}"
+;;
+*)
+  doRun "${@}"
+;;
+esac

--- a/scripts/src/main/resources/scripts/command/gcloud
+++ b/scripts/src/main/resources/scripts/command/gcloud
@@ -31,11 +31,12 @@ function doConfig() {
 # the path of gcloud modules must be added to python's sys.path via .pth file
 function doSetPth() {
   local wsl_path="${GCLOUD_HOME}/lib"
-  local win_path="$(cygpath -w ${wsl_path})"
+  local win_path
   local pth_file="${DEVON_IDE_HOME}/software/python/ext_modules.pth"
   if doIsWindows
   then
-    if ! grep -Fq "${win_path}" "${pth_file}"
+    win_path="$(cygpath -w "${wsl_path}")"
+    if ! grep -Fq "${win_path}" "${pth_file}" &> /dev/null
     then
       echo -e "\n${win_path}" >> "${pth_file}"
     fi


### PR DESCRIPTION
GCloud CLI is added to the ide as a commandlet. It only works for Windows systems as it requires Python to run. After Python is fixed for MacOS and Linux, we can update this command. 

Related issue: #1004 