### PR TITLE
#1052: Fix leading spaces on macOS

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -2,6 +2,12 @@
 
 This file documents all notable changes to https://github.com/devonfw/ide[devonfw-ide].
 
+== 2023.02.001
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/ide/issues/1052[#1052]: Fix leading spaces on MacOS
+
 == 2023.01.001
 
 Release with new features and bugfixes:

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -836,7 +836,7 @@ function doReplaceExtractedSkipSingleFolder() {
   if [ "${#*}" = 1 ] && [ "${1%.app}" = "${1}" ] && [ -d "${1}" ]
   then
     files="$(find "${dir}" -maxdepth 1 -mindepth 1 -exec basename {} \;)"
-    anz_files="$(echo "${files}" | wc -w)"
+    anz_files="$(echo "${files}" | awk 'END{print NR}')"
     while [ "${anz_files}" == "1" ]
     do
       if [ -d "${dir}/${files}" ] && [ "${files}" != "bin" ] && [ "${files%.app}" = "${files}" ]
@@ -846,7 +846,7 @@ function doReplaceExtractedSkipSingleFolder() {
         break
       fi
       files="$(find "${dir}" -maxdepth 1 -mindepth 1 -exec basename {} \;)"
-      anz_files="$(echo "${files}" | wc -w)"
+      anz_files="$(echo "${files}" | awk 'END{print NR}')"
     done
     source_dir="${dir}"
     doDebug "Changing source directory from ${root_dir} to ${source_dir} due to single folder."

--- a/scripts/src/test/bash/integration-test-custom-tools
+++ b/scripts/src/test/bash/integration-test-custom-tools
@@ -1,16 +1,13 @@
 #!/bin/bash
 
-source "$(dirname "${0}")"/functions-test
-
 CLI="${PWD}/scripts/devon"
 REPO_URL="https://repo1.maven.org/maven2/com/palantir/launching"
-MAC_PATH=$(doIsMacOs && echo "service/" || echo "")
 TOOL_A="go-init"
 TOOL_VERSION_A="1.22.0"
-TOOL_PATH_A="${PWD}/software/${TOOL_A}/${MAC_PATH}bin/darwin-amd64/${TOOL_A}"
+TOOL_PATH_A="${PWD}/software/${TOOL_A}/bin/darwin-amd64/${TOOL_A}"
 TOOL_B="go-java-launcher"
 TOOL_VERSION_B="1.34.0"
-TOOL_PATH_B="${PWD}/software/${TOOL_B}/${MAC_PATH}bin/darwin-amd64/${TOOL_B}"
+TOOL_PATH_B="${PWD}/software/${TOOL_B}/service/bin/darwin-amd64/${TOOL_B}"
 CUSTOM_TOOLS="DEVON_IDE_CUSTOM_TOOLS=(${TOOL_A}:${TOOL_VERSION_A}:all:${REPO_URL} ${TOOL_B}:${TOOL_VERSION_B}:all:)"
 
 echo -e "\n${CUSTOM_TOOLS}" >> "${PWD}/settings/devon.properties"

--- a/scripts/src/test/bash/integration-test-custom-tools
+++ b/scripts/src/test/bash/integration-test-custom-tools
@@ -7,7 +7,7 @@ TOOL_VERSION_A="1.22.0"
 TOOL_PATH_A="${PWD}/software/${TOOL_A}/bin/darwin-amd64/${TOOL_A}"
 TOOL_B="go-java-launcher"
 TOOL_VERSION_B="1.34.0"
-TOOL_PATH_B="${PWD}/software/${TOOL_B}/service/bin/darwin-amd64/${TOOL_B}"
+TOOL_PATH_B="${PWD}/software/${TOOL_B}/bin/darwin-amd64/${TOOL_B}"
 CUSTOM_TOOLS="DEVON_IDE_CUSTOM_TOOLS=(${TOOL_A}:${TOOL_VERSION_A}:all:${REPO_URL} ${TOOL_B}:${TOOL_VERSION_B}:all:)"
 
 echo -e "\n${CUSTOM_TOOLS}" >> "${PWD}/settings/devon.properties"

--- a/scripts/src/test/bash/integration-test-custom-tools
+++ b/scripts/src/test/bash/integration-test-custom-tools
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+source "$(dirname "${0}")"/functions-test
+
 CLI="${PWD}/scripts/devon"
 REPO_URL="https://repo1.maven.org/maven2/com/palantir/launching"
+MAC_PATH=$(doIsMacOs && echo "service/" || echo "")
 TOOL_A="go-init"
 TOOL_VERSION_A="1.22.0"
-TOOL_PATH_A="${PWD}/software/${TOOL_A}/service/bin/darwin-amd64/${TOOL_A}"
+TOOL_PATH_A="${PWD}/software/${TOOL_A}/${MAC_PATH}bin/darwin-amd64/${TOOL_A}"
 TOOL_B="go-java-launcher"
 TOOL_VERSION_B="1.34.0"
-TOOL_PATH_B="${PWD}/software/${TOOL_B}/service/bin/darwin-amd64/${TOOL_B}"
+TOOL_PATH_B="${PWD}/software/${TOOL_B}/${MAC_PATH}bin/darwin-amd64/${TOOL_B}"
 CUSTOM_TOOLS="DEVON_IDE_CUSTOM_TOOLS=(${TOOL_A}:${TOOL_VERSION_A}:all:${REPO_URL} ${TOOL_B}:${TOOL_VERSION_B}:all:)"
 
 echo -e "\n${CUSTOM_TOOLS}" >> "${PWD}/settings/devon.properties"


### PR DESCRIPTION
This PR fix the behaviour of `doReplaceExtractedSkipSingleFolder` on MacOS system without M1 chips. The reason of the bug was that `wc-w` may produce leading spaces,

Related issue: #1052