### PR TITLE
#1062: Update devon4j to 2023.01.001

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/ide[devonf
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/ide/issues/1062[#1062]: Migration support for devon4j 2023.01.001
 * https://github.com/devonfw/ide/issues/1052[#1052]: Fix leading spaces on MacOS
 * https://github.com/devonfw/ide/issues/1022[#1022]: suppress confusing windows process result messages like The operation completed successfully.
 * https://github.com/devonfw/ide/issues/1051[#1051]: creation of a documentation for using the software IObit Unlocker to find processes that block specific files

--- a/configurator/src/main/java/com/devonfw/tools/ide/migrator/Migrations.java
+++ b/configurator/src/main/java/com/devonfw/tools/ide/migrator/Migrations.java
@@ -208,6 +208,9 @@ public class Migrations {
         .replaceProperty("spring.boot.version", "2.7.6") //
         .replaceProperty("cxf.version", "3.5.4") //
         .and() //
+        .next().to(VersionIdentifier.ofDevon4j("2023.01.001")).pom() //
+        .replaceProperty("devon4j.version", "2023.01.001") //
+        .and() //
         .next().build();
   }
 


### PR DESCRIPTION
Update devon4j to 2023.01.001 | submodules and migrations

Related issue: https://github.com/devonfw/ide/issues/1062