### PR TITLE
#1162 android studio json urls

### DIFF
--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/AbstractUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/AbstractUrlUpdater.java
@@ -1,23 +1,5 @@
 package com.devonfw.tools.ide.url.updater;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpClient.Redirect;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.Locale;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.devonfw.tools.ide.common.OperatingSystem;
 import com.devonfw.tools.ide.common.SystemArchitecture;
 import com.devonfw.tools.ide.url.model.file.UrlChecksum;
@@ -34,6 +16,23 @@ import com.devonfw.tools.ide.url.model.folder.UrlVersion;
 import com.devonfw.tools.ide.util.DateTimeUtil;
 import com.devonfw.tools.ide.util.HexUtil;
 import com.google.common.base.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Abstract base implementation of {@link UrlUpdater}. Contains methods for retrieving response bodies from URLs,
@@ -78,7 +77,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
 
   /**
    * @return the combination of {@link #getTool() tool} and {@link #getEdition() edition} but simplified if both are
-   *         equal.
+   * equal.
    */
   protected final String getToolWithEdition() {
 
@@ -319,7 +318,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
    * @param urlVersion the UrlVersion instance to create or refresh the status JSON file for.
    * @param url the checked download URL.
    * @param update - {@code true} in case the URL was updated (verification), {@code false} otherwise (version/URL
-   *        initially added).
+   * initially added).
    */
   @SuppressWarnings("null") // Eclipse is too stupid to check this
   private void doUpdateStatusJson(boolean success, int statusCode, UrlVersion urlVersion, String url, boolean update) {
@@ -506,8 +505,8 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
         || vLower.contains("preview") || vLower.contains("test") || vLower.contains("tech-preview") //
         || vLower.contains("-pre") || vLower.startsWith("ce-")
         // vscode nonsense
-        || vLower.startsWith("bad") || vLower.contains("vsda-") || vLower.contains("translation/")
-        || vLower.contains("-insiders")) {
+        || vLower.startsWith("bad") || vLower.contains("vsda-") || vLower.contains("translation/") || vLower.contains(
+        "-insiders")) {
       return null;
     }
     return version;

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/AbstractUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/AbstractUrlUpdater.java
@@ -127,7 +127,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
   /**
    * Updates a tool version with the given arguments (OS independent).
    *
-   * @param urlVersion the UrlVersion instance to update.
+   * @param urlVersion the {@link UrlVersion} instance to update.
    * @param downloadUrl the URL of the download for the tool.
    * @return true if the version was successfully updated, false otherwise.
    */
@@ -139,14 +139,14 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
   /**
    * Updates a tool version with the given arguments.
    *
-   * @param urlVersion the UrlVersion instance to update.
+   * @param urlVersion the {@link UrlVersion} instance to update.
    * @param downloadUrl the URL of the download for the tool.
-   * @param os the operating system type for the tool (can be null).
+   * @param os the {@link OperatingSystem} for the tool (can be null).
    * @return true if the version was successfully updated, false otherwise.
    */
   protected boolean doAddVersion(UrlVersion urlVersion, String downloadUrl, OperatingSystem os) {
 
-    return doAddVersion(urlVersion, downloadUrl, os, null);
+    return doAddVersion(urlVersion, downloadUrl, os, null, "");
   }
 
   /**
@@ -156,10 +156,11 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
    * @param url the URL of the download for the tool.
    * @param os the optional {@link OperatingSystem}.
    * @param architecture the optional {@link SystemArchitecture}.
+   * @param checksum String of the checksum to utilize
    * @return {@code true} if the version was successfully updated, {@code false} otherwise.
    */
   protected boolean doAddVersion(UrlVersion urlVersion, String url, OperatingSystem os,
-      SystemArchitecture architecture) {
+      SystemArchitecture architecture, String checksum) {
 
     String version = urlVersion.getName();
     url = url.replace("${version}", version);
@@ -171,25 +172,24 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
     }
     url = url.replace("${edition}", getEdition());
 
-    return checkDownloadUrl(url, urlVersion, os, architecture);
+    if (checksum.isEmpty()){
+      return checkDownloadUrl(url, urlVersion, os, architecture);
+    } else {
+      return checkDownloadUrl(url, urlVersion, os, architecture, checksum);
+    }
+
   }
 
-  protected boolean doAddVersion(UrlVersion urlVersion, String url, OperatingSystem os, SystemArchitecture architecture,
-      String checksum) {
-
-    String version = urlVersion.getName();
-    url = url.replace("${version}", version);
-    if (os != null) {
-      url = url.replace("${os}", os.toString());
-    }
-    if (architecture != null) {
-      url = url.replace("${arch}", architecture.toString());
-    }
-    url = url.replace("${edition}", getEdition());
-
-    return checkDownloadUrl(url, urlVersion, os, architecture, checksum);
-  }
-
+  /**
+   * Checks the download URL and takes the provided checksum into account instead of downloading the file and generating the checksum
+   *
+   * @param url the URL of the download to check.
+   * @param urlVersion the {@link UrlVersion} where to store the collected information like status and checksum.
+   * @param os the {@link OperatingSystem}
+   * @param architecture the {@link SystemArchitecture}
+   * @param checksum String of the checksum to use
+   * @return {@code true} if the download was checked successfully, {@code false} otherwise.
+   */
   private boolean checkDownloadUrl(String url, UrlVersion urlVersion, OperatingSystem os,
       SystemArchitecture architecture, String checksum) {
 
@@ -218,6 +218,8 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
   /**
    * @param url the URL of the download to check.
    * @param urlVersion the {@link UrlVersion} where to store the collected information like status and checksum.
+   * @param os the {@link OperatingSystem}
+   * @param architecture the {@link SystemArchitecture}
    * @return {@code true} if the download was checked successfully, {@code false} otherwise.
    */
   private boolean checkDownloadUrl(String url, UrlVersion urlVersion, OperatingSystem os,
@@ -315,7 +317,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
    *
    * @param success - {@code true} on successful HTTP response, {@code false} otherwise.
    * @param statusCode the HTTP status code of the response.
-   * @param urlVersion the UrlVersion instance to create or refresh the status JSON file for.
+   * @param urlVersion the {@link UrlVersion} instance to create or refresh the status JSON file for.
    * @param url the checked download URL.
    * @param update - {@code true} in case the URL was updated (verification), {@code false} otherwise (version/URL
    * initially added).
@@ -397,7 +399,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
   /**
    * Updates the tool's versions in the URL repository.
    *
-   * @param urlRepository the URL repository to update
+   * @param urlRepository the {@link UrlRepository} to update
    */
   @Override
   public void update(UrlRepository urlRepository) {
@@ -424,7 +426,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
   /**
    * Update existing versions of the tool in the URL repository.
    *
-   * @param edition the URL edition to update
+   * @param edition the {@link UrlEdition} to update
    */
   protected void updateExistingVersions(UrlEdition edition) {
 
@@ -542,7 +544,7 @@ public abstract class AbstractUrlUpdater implements UrlUpdater {
   /**
    * Updates the version of a given URL version.
    *
-   * @param urlVersion the URL version to be updated
+   * @param urlVersion the {@link UrlVersion} to be updated
    */
   protected abstract void addVersion(UrlVersion urlVersion);
 

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/androidstudio/AndroidJsonDownload.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/androidstudio/AndroidJsonDownload.java
@@ -1,0 +1,34 @@
+package com.devonfw.tools.ide.url.updater.androidstudio;
+
+import com.devonfw.tools.ide.common.JsonObject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * JSON data object for a download of Android. We map only properties that we are interested in and let jackson ignore
+ * all others.
+ */
+public class AndroidJsonDownload implements JsonObject {
+
+  @JsonProperty("link")
+  private String link;
+
+  @JsonProperty("checksum")
+  private String checksum;
+
+  /**
+   * @return link
+   */
+  public String getLink() {
+
+    return link;
+  }
+
+  /**
+   * @return checksum
+   */
+  public String getChecksum() {
+
+    return checksum;
+  }
+
+}

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/androidstudio/AndroidJsonItem.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/androidstudio/AndroidJsonItem.java
@@ -2,6 +2,8 @@ package com.devonfw.tools.ide.url.updater.androidstudio;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 /**
  * JSON data object for an item of Android. We map only properties that we are interested in and let jackson ignore all
  * others.
@@ -11,12 +13,23 @@ public class AndroidJsonItem {
   @JsonProperty("version")
   private String version;
 
+  @JsonProperty("download")
+  private List<AndroidJsonDownload> download;
+
   /**
    * @return version
    */
   public String getVersion() {
 
     return this.version;
+  }
+
+  /**
+   * @return download
+   */
+  public List<AndroidJsonDownload> getDownload() {
+
+    return download;
   }
 
 }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/androidstudio/AndroidStudioUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/androidstudio/AndroidStudioUrlUpdater.java
@@ -1,38 +1,36 @@
 package com.devonfw.tools.ide.url.updater.androidstudio;
 
-import java.util.Collection;
-
+import com.devonfw.tools.ide.json.mapping.JsonMapping;
+import com.devonfw.tools.ide.url.model.folder.UrlEdition;
+import com.devonfw.tools.ide.url.model.folder.UrlRepository;
+import com.devonfw.tools.ide.url.model.folder.UrlTool;
 import com.devonfw.tools.ide.url.model.folder.UrlVersion;
 import com.devonfw.tools.ide.url.updater.JsonUrlUpdater;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
 
 /**
  * {@link JsonUrlUpdater} for Android Studio.
  */
 public class AndroidStudioUrlUpdater extends JsonUrlUpdater<AndroidJsonObject> {
 
-  /** The base URL for the download of the software */
-  private final static String DOWNLOAD_BASE_URL = "https://redirector.gvt1.com";
-
   /** The base URL for the version json file */
   private final static String VERSION_BASE_URL = "https://jb.gg";
-
-  /** The path of the download URL */
-  private final static String DOWNLOAD_URL_PATH = "edgedl/android/studio/ide-zips";
 
   /** The name of the version json file */
   private final static String VERSION_FILENAME = "android-studio-releases-list.json";
 
-  /**
-   * @return String of download base URL
-   */
-  protected String getDownloadBaseUrl() {
-    return DOWNLOAD_BASE_URL;
-  }
+  private static final Logger logger = LoggerFactory.getLogger(AndroidStudioUrlUpdater.class);
 
   /**
    * @return String of version base URL
    */
   protected String getVersionBaseUrl() {
+
     return VERSION_BASE_URL;
   }
 
@@ -43,22 +41,57 @@ public class AndroidStudioUrlUpdater extends JsonUrlUpdater<AndroidJsonObject> {
   }
 
   @Override
+  public void update(UrlRepository urlRepository) {
+
+    UrlTool tool = urlRepository.getOrCreateChild(getTool());
+    UrlEdition edition = tool.getOrCreateChild(getEdition());
+    updateExistingVersions(edition);
+    String toolWithEdition = getToolWithEdition();
+    ObjectMapper MAPPER = JsonMapping.create();
+    String url = doGetVersionUrl();
+    try {
+      String response = doGetResponseBodyAsString(url);
+      AndroidJsonObject jsonObject = MAPPER.readValue(response, getJsonObjectType());
+
+      List<AndroidJsonItem> items = jsonObject.getContent().getItem();
+
+      for (AndroidJsonItem item : items) {
+        String version = item.getVersion();
+        if (edition.getChild(version) == null) {
+          try {
+            UrlVersion urlVersion = edition.getOrCreateChild(version);
+            for (AndroidJsonDownload download : item.getDownload()) {
+
+              if (download.getLink().contains("windows.zip")) {
+                doAddVersion(urlVersion, download.getLink(), WINDOWS, X64, download.getChecksum());
+              } else if (download.getLink().contains("linux.tar.gz")) {
+                doAddVersion(urlVersion, download.getLink(), LINUX, X64, download.getChecksum());
+              } else if (download.getLink().contains("mac.zip")) {
+                doAddVersion(urlVersion, download.getLink(), MAC, X64, download.getChecksum());
+              } else if (download.getLink().contains("mac_arm.zip")) {
+                doAddVersion(urlVersion, download.getLink(), MAC, ARM64, download.getChecksum());
+              } else {
+                logger.info("Unknown architecture for tool {} version {} and download {}.", toolWithEdition, version,
+                    download.getLink());
+              }
+            }
+            urlVersion.save();
+          } catch (Exception e) {
+            logger.error("For tool {} we failed to add version {}.", toolWithEdition, version, e);
+          }
+
+        }
+      }
+    } catch (Exception e2) {
+      throw new IllegalStateException("Error while getting versions from JSON API " + url, e2);
+    }
+
+  }
+
+  @Override
   protected void addVersion(UrlVersion urlVersion) {
 
-    String version = urlVersion.getName();
-
-    String versionDownloadUrl = getDownloadBaseUrl() + "/" + DOWNLOAD_URL_PATH + "/" + version + "/" + "android-studio" + "-" + version + "-";
-
-    String downloadUrlWindows = versionDownloadUrl + "windows.zip";
-    String downloadUrlLinux = versionDownloadUrl + "linux.tar.gz";
-    String downloadUrlMac = versionDownloadUrl + "mac.zip";
-    String downloadUrlMacArm64 = versionDownloadUrl + "mac_arm.zip";
-
-    doAddVersion(urlVersion, downloadUrlWindows, WINDOWS);
-    doAddVersion(urlVersion, downloadUrlLinux, LINUX);
-    doAddVersion(urlVersion, downloadUrlMac, MAC);
-    doAddVersion(urlVersion, downloadUrlMacArm64, MAC, ARM64);
-
+    throw new IllegalStateException();
   }
 
   @Override
@@ -76,10 +109,7 @@ public class AndroidStudioUrlUpdater extends JsonUrlUpdater<AndroidJsonObject> {
   @Override
   protected void collectVersionsFromJson(AndroidJsonObject jsonItem, Collection<String> versions) {
 
-    AndroidJsonContent content = jsonItem.getContent();
-    for (AndroidJsonItem item : content.getItem()) {
-      String version = item.getVersion();
-      addVersion(version, versions);
-    }
+    throw new IllegalStateException();
   }
+
 }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/docker/DockerDesktopUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/docker/DockerDesktopUrlUpdater.java
@@ -33,8 +33,8 @@ public class DockerDesktopUrlUpdater extends WebsiteUrlUpdater {
       if (!success) {
         return;
       }
-      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/amd64/" + code + "/Docker.dmg", MAC, X64);
-      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/arm64/" + code + "/Docker.dmg", MAC, ARM64);
+      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/amd64/" + code + "/Docker.dmg", MAC, X64, "");
+      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/arm64/" + code + "/Docker.dmg", MAC, ARM64, "");
     } else {
       // For the latest version, there is no code in the url.
       // TODO but that means that the implementation is wrong as the URL will then change later and is therefore
@@ -46,8 +46,8 @@ public class DockerDesktopUrlUpdater extends WebsiteUrlUpdater {
       if (!success) {
         return;
       }
-      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/amd64/Docker.dmg", MAC, X64);
-      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/arm64/Docker.dmg", MAC, ARM64);
+      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/amd64/Docker.dmg", MAC, X64, "");
+      doAddVersion(urlVersion, "https://desktop.docker.com/mac/main/arm64/Docker.dmg", MAC, ARM64, "");
     }
 
   }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/docker/DockerRancherDesktopUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/docker/DockerRancherDesktopUrlUpdater.java
@@ -43,7 +43,7 @@ public class DockerRancherDesktopUrlUpdater extends GithubUrlUpdater {
     String baseUrl = "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v${version}/Rancher.Desktop";
     doAddVersion(urlVersion, baseUrl + ".Setup.${version}.exe", WINDOWS);
     doAddVersion(urlVersion, baseUrl + "-${version}.x86_64.dmg", MAC);
-    doAddVersion(urlVersion, baseUrl + "-${version}.aarch64.dmg", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "-${version}.aarch64.dmg", MAC, ARM64, "");
 
   }
 }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/dotnet/DotNetUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/dotnet/DotNetUrlUpdater.java
@@ -23,15 +23,15 @@ public class DotNetUrlUpdater extends GithubUrlUpdater {
   protected void addVersion(UrlVersion urlVersion) {
 
     String baseUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/dotnet-sdk-${version}-";
-    boolean ok1 = doAddVersion(urlVersion, baseUrl + "win-x64.exe", WINDOWS, X64);
-    boolean ok2 = doAddVersion(urlVersion, baseUrl + "win-arm64.exe", WINDOWS, ARM64);
+    boolean ok1 = doAddVersion(urlVersion, baseUrl + "win-x64.exe", WINDOWS, X64, "");
+    boolean ok2 = doAddVersion(urlVersion, baseUrl + "win-arm64.exe", WINDOWS, ARM64, "");
     if (!ok1 && !ok2) {
       return;
     }
-    doAddVersion(urlVersion, baseUrl + "linux-x64.tar.gz", LINUX, X64);
-    doAddVersion(urlVersion, baseUrl + "linux-arm64.tar.gz", LINUX, ARM64);
-    doAddVersion(urlVersion, baseUrl + "osx-x64.tar.gz", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + "osx-arm64.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "linux-x64.tar.gz", LINUX, X64, "");
+    doAddVersion(urlVersion, baseUrl + "linux-arm64.tar.gz", LINUX, ARM64, "");
+    doAddVersion(urlVersion, baseUrl + "osx-x64.tar.gz", MAC, X64, "");
+    doAddVersion(urlVersion, baseUrl + "osx-arm64.tar.gz", MAC, ARM64, "");
   }
 
   @Override

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/eclipse/EclipseUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/eclipse/EclipseUrlUpdater.java
@@ -60,14 +60,14 @@ public abstract class EclipseUrlUpdater extends WebsiteUrlUpdater {
   private boolean doUpdateVersions(UrlVersion urlVersion, String baseUrl) {
 
     boolean ok;
-    ok = doAddVersion(urlVersion, baseUrl + "win32-x86_64.zip", WINDOWS, X64);
+    ok = doAddVersion(urlVersion, baseUrl + "win32-x86_64.zip", WINDOWS, X64, "");
     if (!ok) {
       return false;
     }
-    ok = doAddVersion(urlVersion, baseUrl + "linux-gtk-x86_64.tar.gz", LINUX, X64);
-    ok = doAddVersion(urlVersion, baseUrl + "linux-gtk-aarch64.tar.gz", LINUX, ARM64);
-    ok = doAddVersion(urlVersion, baseUrl + "macosx-cocoa-x86_64.tar.gz", MAC, X64);
-    ok = doAddVersion(urlVersion, baseUrl + "macosx-cocoa-aarch64.tar.gz", MAC, ARM64);
+    ok = doAddVersion(urlVersion, baseUrl + "linux-gtk-x86_64.tar.gz", LINUX, X64, "");
+    ok = doAddVersion(urlVersion, baseUrl + "linux-gtk-aarch64.tar.gz", LINUX, ARM64, "");
+    ok = doAddVersion(urlVersion, baseUrl + "macosx-cocoa-x86_64.tar.gz", MAC, X64, "");
+    ok = doAddVersion(urlVersion, baseUrl + "macosx-cocoa-aarch64.tar.gz", MAC, ARM64, "");
     return ok;
   }
 

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/gh/GhUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/gh/GhUrlUpdater.java
@@ -23,11 +23,11 @@ public class GhUrlUpdater extends GithubUrlUpdater {
   protected void addVersion(UrlVersion urlVersion) {
 
     String baseUrl = "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_";
-    doAddVersion(urlVersion, baseUrl + "windows_amd64.zip", WINDOWS, X64);
-    doAddVersion(urlVersion, baseUrl + "linux_amd64.tar.gz", LINUX, X64);
-    doAddVersion(urlVersion, baseUrl + "linux_arm64.tar.gz", LINUX, ARM64);
-    doAddVersion(urlVersion, baseUrl + "macOS_amd64.tar.gz", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + "macOS_arm64.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "windows_amd64.zip", WINDOWS, X64, "");
+    doAddVersion(urlVersion, baseUrl + "linux_amd64.tar.gz", LINUX, X64, "");
+    doAddVersion(urlVersion, baseUrl + "linux_arm64.tar.gz", LINUX, ARM64, "");
+    doAddVersion(urlVersion, baseUrl + "macOS_amd64.tar.gz", MAC, X64, "");
+    doAddVersion(urlVersion, baseUrl + "macOS_arm64.tar.gz", MAC, ARM64, "");
   }
 
   @Override

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/graalvm/GraalVmUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/graalvm/GraalVmUrlUpdater.java
@@ -23,10 +23,10 @@ public class GraalVmUrlUpdater extends GithubUrlUpdater {
   protected void addVersion(UrlVersion urlVersion) {
 
     String baseUrl = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/graalvm-ce-java11-";
-    doAddVersion(urlVersion, baseUrl + "windows-amd64-${version}.zip", WINDOWS, X64);
-    doAddVersion(urlVersion, baseUrl + "linux-amd64-${version}.tar.gz", LINUX, X64);
-    doAddVersion(urlVersion, baseUrl + "darwin-amd64-${version}.tar.gz", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + "darwin-aarch64-${version}.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "windows-amd64-${version}.zip", WINDOWS, X64, "");
+    doAddVersion(urlVersion, baseUrl + "linux-amd64-${version}.tar.gz", LINUX, X64, "");
+    doAddVersion(urlVersion, baseUrl + "darwin-amd64-${version}.tar.gz", MAC, X64, "");
+    doAddVersion(urlVersion, baseUrl + "darwin-aarch64-${version}.tar.gz", MAC, ARM64, "");
 
   }
 

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/helm/HelmUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/helm/HelmUrlUpdater.java
@@ -27,7 +27,7 @@ public class HelmUrlUpdater extends GithubUrlUpdater {
     doAddVersion(urlVersion, baseUrl + "windows-amd64.zip", WINDOWS);
     doAddVersion(urlVersion, baseUrl + "linux-amd64.tar.gz", LINUX);
     doAddVersion(urlVersion, baseUrl + "darwin-amd64.tar.gz", MAC);
-    doAddVersion(urlVersion, baseUrl + "darwin-arm64.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "darwin-arm64.tar.gz", MAC, ARM64, "");
   }
 
 }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/kotlinc/KotlincNativeUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/kotlinc/KotlincNativeUrlUpdater.java
@@ -19,10 +19,10 @@ public class KotlincNativeUrlUpdater extends WebsiteUrlUpdater {
   protected void addVersion(UrlVersion urlVersion) {
 
     String baseUrl = "https://github.com/JetBrains/kotlin/releases/download/v${version}/kotlin-native-";
-    doAddVersion(urlVersion, baseUrl + "windows-x86_64-${version}.zip", WINDOWS, X64);
-    doAddVersion(urlVersion, baseUrl + "linux-x86_64-${version}.tar.gz", LINUX, X64);
-    doAddVersion(urlVersion, baseUrl + "macos-x86_64-${version}.tar.gz", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + "macos-aarch64-${version}.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "windows-x86_64-${version}.zip", WINDOWS, X64, "");
+    doAddVersion(urlVersion, baseUrl + "linux-x86_64-${version}.tar.gz", LINUX, X64, "");
+    doAddVersion(urlVersion, baseUrl + "macos-x86_64-${version}.tar.gz", MAC, X64, "");
+    doAddVersion(urlVersion, baseUrl + "macos-aarch64-${version}.tar.gz", MAC, ARM64, "");
   }
 
   @Override

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/lazydocker/LazyDockerUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/lazydocker/LazyDockerUrlUpdater.java
@@ -35,12 +35,12 @@ public class LazyDockerUrlUpdater extends GithubUrlUpdater {
   protected void addVersion(UrlVersion urlVersion) {
 
     String baseUrl = "https://github.com/jesseduffield/lazydocker/releases/download/v${version}/lazydocker_${version}_";
-    doAddVersion(urlVersion, baseUrl + "Windows_x86_64.zip", WINDOWS, X64);
-    doAddVersion(urlVersion, baseUrl + "Windows_arm64.zip", WINDOWS, ARM64);
-    doAddVersion(urlVersion, baseUrl + "Linux_x86_64.tar.gz", LINUX, X64);
-    doAddVersion(urlVersion, baseUrl + "Linux_arm64.tar.gz", LINUX, ARM64);
-    doAddVersion(urlVersion, baseUrl + "Darwin_x86_64.tar.gz", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + "Darwin_arm64.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "Windows_x86_64.zip", WINDOWS, X64, "");
+    doAddVersion(urlVersion, baseUrl + "Windows_arm64.zip", WINDOWS, ARM64, "");
+    doAddVersion(urlVersion, baseUrl + "Linux_x86_64.tar.gz", LINUX, X64, "");
+    doAddVersion(urlVersion, baseUrl + "Linux_arm64.tar.gz", LINUX, ARM64, "");
+    doAddVersion(urlVersion, baseUrl + "Darwin_x86_64.tar.gz", MAC, X64, "");
+    doAddVersion(urlVersion, baseUrl + "Darwin_arm64.tar.gz", MAC, ARM64, "");
   }
 
 }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/node/NodeUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/node/NodeUrlUpdater.java
@@ -30,11 +30,11 @@ public class NodeUrlUpdater extends GithubUrlUpdater {
 
     String baseUrl = "https://nodejs.org/dist/${version}/node-${version}-";
     doAddVersion(urlVersion, baseUrl + "win-x64.zip", WINDOWS);
-    doAddVersion(urlVersion, baseUrl + "win-aarch64.zip", WINDOWS, ARM64);
+    doAddVersion(urlVersion, baseUrl + "win-aarch64.zip", WINDOWS, ARM64, "");
     doAddVersion(urlVersion, baseUrl + "linux-x64.tar.gz", LINUX);
-    doAddVersion(urlVersion, baseUrl + "linux-aarch64.tar.gz", LINUX, ARM64);
+    doAddVersion(urlVersion, baseUrl + "linux-aarch64.tar.gz", LINUX, ARM64, "");
     doAddVersion(urlVersion, baseUrl + "darwin-x64.tar.gz", MAC);
-    doAddVersion(urlVersion, baseUrl + "darwin-aarch64.tar.gz", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "darwin-aarch64.tar.gz", MAC, ARM64, "");
   }
 
 }

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/npm/NpmUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/npm/NpmUrlUpdater.java
@@ -19,10 +19,10 @@ public class NpmUrlUpdater extends WebsiteUrlUpdater {
   protected void addVersion(UrlVersion urlVersion) {
 
     String baseUrl = "https://nodejs.org/dist/v${version}/node-v${version}";
-    doAddVersion(urlVersion, baseUrl + "-win-x64.zip", WINDOWS, X64);
-    doAddVersion(urlVersion, baseUrl + "-darwin-x64.tar.gz", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + ".pkg", MAC, ARM64);
-    doAddVersion(urlVersion, baseUrl + "-linux-x64.tar.xz", LINUX, X64);
+    doAddVersion(urlVersion, baseUrl + "-win-x64.zip", WINDOWS, X64, "");
+    doAddVersion(urlVersion, baseUrl + "-darwin-x64.tar.gz", MAC, X64, "");
+    doAddVersion(urlVersion, baseUrl + ".pkg", MAC, ARM64, "");
+    doAddVersion(urlVersion, baseUrl + "-linux-x64.tar.xz", LINUX, X64, "");
   }
 
   @Override

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/terraform/TerraformUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/terraform/TerraformUrlUpdater.java
@@ -32,7 +32,7 @@ public class TerraformUrlUpdater extends GithubUrlUpdater {
     doAddVersion(urlVersion, baseUrl + "windows_amd64.zip", WINDOWS);
     doAddVersion(urlVersion, baseUrl + "linux_amd64.zip", LINUX);
     doAddVersion(urlVersion, baseUrl + "darwin_amd64.zip", MAC);
-    doAddVersion(urlVersion, baseUrl + "darwin_arm64.zip", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "darwin_arm64.zip", MAC, ARM64, "");
   }
 
 }

--- a/url-updater/src/test/java/com/devonfw/tools/ide/integrationtests/AndroidStudioUrlUpdaterMock.java
+++ b/url-updater/src/test/java/com/devonfw/tools/ide/integrationtests/AndroidStudioUrlUpdaterMock.java
@@ -12,12 +12,6 @@ public class AndroidStudioUrlUpdaterMock extends AndroidStudioUrlUpdater {
   private final static String TEST_BASE_URL = "http://localhost:8080";
 
   @Override
-  protected String getDownloadBaseUrl() {
-
-    return TEST_BASE_URL;
-  }
-
-  @Override
   protected String getVersionBaseUrl() {
 
     return TEST_BASE_URL;


### PR DESCRIPTION
Addresses/Fixes: #1162 

Implements:
* added first implementation of download URL and checksum extraction from version json
* fixed updateStatusJson (can now handle initial URL generate using update false)
* cleaned up AndroidStudioUrlUpdater and test mock
* added AndroidJsonDownload
* added download to AndroidJsonItem
* removed duplicated doAddVersion method (added check for checksum param instead)
* added new checksum param to doAddVersion (defaults to empty string)
* updated javadocs
* added links to javadocs
