### PR TITLE
#1142 wrong checksum in ide urls for npm 

### DIFF
--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/npm/NpmUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/npm/NpmUrlUpdater.java
@@ -18,11 +18,7 @@ public class NpmUrlUpdater extends WebsiteUrlUpdater {
   @Override
   protected void addVersion(UrlVersion urlVersion) {
 
-    String baseUrl = "https://nodejs.org/dist/v${version}/node-v${version}";
-    doAddVersion(urlVersion, baseUrl + "-win-x64.zip", WINDOWS, X64, "");
-    doAddVersion(urlVersion, baseUrl + "-darwin-x64.tar.gz", MAC, X64, "");
-    doAddVersion(urlVersion, baseUrl + ".pkg", MAC, ARM64, "");
-    doAddVersion(urlVersion, baseUrl + "-linux-x64.tar.xz", LINUX, X64, "");
+    doAddVersion(urlVersion,"https://registry.npmjs.org/npm/-/npm-${version}.tgz");
   }
 
   @Override
@@ -34,6 +30,11 @@ public class NpmUrlUpdater extends WebsiteUrlUpdater {
   @Override
   protected Pattern getVersionPattern() {
 
-    return Pattern.compile("(\\d\\.\\d{1,2}\\.\\d+)");
+    return Pattern.compile("npm-(\\d\\.\\d{1,2}\\.\\d+)");
+  }
+  @Override
+  protected String getVersionPrefixToRemove() {
+    
+    return "npm-";
   }
 }


### PR DESCRIPTION
partially solving #1142 

- fixed the wrong url, which was used for the npm baseURL

- changed the Version pattern, so to not include non existing npm versions.

