### PR TITLE
#1232: added MacOSX zip URLs

### DIFF
--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/gh/GhUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/gh/GhUrlUpdater.java
@@ -33,8 +33,10 @@ public class GhUrlUpdater extends GithubUrlUpdater {
     doAddVersion(urlVersion, baseUrl + "linux_amd64.tar.gz", LINUX, X64);
     doAddVersion(urlVersion, baseUrl + "linux_arm64.tar.gz", LINUX, ARM64);
     doAddVersion(urlVersion, baseUrl + "macOS_amd64.tar.gz", MAC, X64);
+    doAddVersion(urlVersion, baseUrl + "macOS_amd64.zip", MAC, X64);
     if (vid.compareVersion(MIN_MAC_ARM_VID).isGreater()) {
       doAddVersion(urlVersion, baseUrl + "macOS_arm64.tar.gz", MAC, ARM64);
+      doAddVersion(urlVersion, baseUrl + "macOS_arm64.zip", MAC, ARM64);
     }
   }
 


### PR DESCRIPTION
Addresses/Fixes: #1232 

Implements:
* simple addition of doAddVersion for zips of later versions