### PR TITLE
#1084: omit default edition in the download filename

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -573,7 +573,7 @@ function doDownload() {
       if [ -z "${filename}" ]
       then
         filename="${software}-${version}"
-        if [ -n "${edition}" ]
+        if [ -n "${edition}" ] && [ "${edition}" != "${software}" ]
         then
           filename="${filename}-${edition}"
         fi


### PR DESCRIPTION
Addition to #1084:
Omit the default edition to keep behavior of previous releases of devonfw-ide.
Small change, big impact: This allows to reuse the download cache and prevents that devonfw-ide will download all the existing files again and create duplicates on the disc.