### PR TITLE
#1084: omit default edition in the download filename at pip

### DIFF
--- a/scripts/src/main/resources/scripts/command/pip
+++ b/scripts/src/main/resources/scripts/command/pip
@@ -39,14 +39,8 @@ function doSetup() {
       # Install pip via python
       doDownload "-" "${PIP_HOME}" "pip" "latest" "" "pip"
       cd "${PIP_HOME}" || exit 255
-      if [ -d  "${DEVON_IDE_HOME}/urls" ]
-      then
-        doDevonCommand python pip-latest-pip-pip.py --no-warn-script-location "--target=${PIP_HOME}" 
-        rm -rf "${PIP_HOME}/pip-latest-pip-pip.py"
-      else
-        doDevonCommand python pip-latest-pip.py --no-warn-script-location "--target=${PIP_HOME}" 
-        rm -rf "${PIP_HOME}/pip-latest-pip.py"
-      fi
+      doDevonCommand python pip-latest-pip.py --no-warn-script-location "--target=${PIP_HOME}" 
+      rm -rf "${PIP_HOME}/pip-latest-pip.py"
       doExtendPath "${PIP_HOME}"
     else
       doEcho "Your operating system is unsupported!"


### PR DESCRIPTION
Addition to https://github.com/devonfw/ide/issues/1084:
Omit the default edition to keep behavior of previous releases of devonfw-ide.
Small change, big impact: This allows to reuse the download cache and prevents that devonfw-ide will download all the existing files again and create duplicates on the disc.

This is coded in pip commandlet, and must be fixed, too