### PR TITLE
#1164: fix jenkins stop command

### DIFF
--- a/documentation/functions.asciidoc
+++ b/documentation/functions.asciidoc
@@ -235,15 +235,16 @@ In case the software is already installed in the resolved version, return `1`.
 
 |=======================
 |*Param*|*Name*  |*Description*
-|`$1`   |software|The name of the software to install.
-|`$2`   |version |The version of the software to install. May be omitted to install the latest version.
-|`$3`   |silent  |The optional silent flag ('silent' to suppress output if already up-to-date or empty for version output).
-|`$4`   |edition |The optional edition of the software to install (e.g. "enterprise" or "community").
-|`$5`   |path    |The absolute target path where to install the software.
-|`$6`   |os      |The optional OS indicator ('-' if OS independent). If omitted the OS will be determined automatically.
-|`$7`   |noUnpack|The optional argument to ignore extracting downloaded files (use 'noUnpack' or leave empty to extract)
-|`$8`   |repo    |The optional software repository.
-|`$9`   |url     |The optional download URL.
+|`$1`   |software           |The name of the software to install.
+|`$2`   |version            |The version of the software to install. May be omitted to install the latest version.
+|`$3`   |silent             |The optional silent flag ('silent' to suppress output if already up-to-date or empty for version output).
+|`$4`   |edition            |The optional edition of the software to install (e.g. "enterprise" or "community").
+|`$5`   |path               |The absolute target path where to install the software.
+|`$6`   |os                 |The optional OS indicator ('-' if OS independent). If omitted the OS will be determined automatically.
+|`$7`   |noUnpack           |The optional argument to ignore extracting downloaded files (use 'noUnpack' or leave empty to extract)
+|`$8`   |repo               |The optional software repository.
+|`$9`   |url                |The optional download URL.
+|`$10`  |target filename    |The optional target filename.
 |=======================
 
 === doInstallWithPackageManager

--- a/scripts/src/main/resources/scripts/command/jenkins
+++ b/scripts/src/main/resources/scripts/command/jenkins
@@ -67,10 +67,12 @@ function doJenkinsCli() {
   then
     admin_password="$(cat "${JENKINS_HOME}"/secrets/initialAdminPassword)"
   fi
+  local auth_file="${JENKINS_HOME}/auth_file"
+  echo "admin:${admin_password}" > "${JENKINS_HOME}/auth_file"
   local jenkins_cli_command="java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins-cli.jar'"
-  echo "${jenkins_cli_command}" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}" "${@}"
+  echo "${jenkins_cli_command}" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "@${auth_file}" "${@}"
   # shellcheck disable=SC2145
-  doRunCommand "${jenkins_cli_command} -s 'http://localhost:${JENKINS_PORT:-9999}' -auth '${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}' ${@}"
+  doRunCommand "${jenkins_cli_command} -s 'http://localhost:${JENKINS_PORT:-9999}' -auth '@${auth_file}' ${@}"
 }
 
 function doStop() {

--- a/scripts/src/main/resources/scripts/command/jenkins
+++ b/scripts/src/main/resources/scripts/command/jenkins
@@ -28,7 +28,7 @@ function doSetup() {
       echo "Jenkins is already installed at ${JENKINS_CLI_HOME}"
     fi
   else
-    if [ ! -f "${JENKINS_HOME}" ]
+    if [ ! -d "${JENKINS_HOME}" ]
     then
       doRunCommand "mkdir '${JENKINS_HOME}'"
     fi

--- a/scripts/src/main/resources/scripts/command/jenkins
+++ b/scripts/src/main/resources/scripts/command/jenkins
@@ -27,14 +27,19 @@ function doSetup() {
       echo "Jenkins is already installed at ${JENKINS_HOME}"
     fi
   else
-    local version=${JENKINS_VERSION:-latest}
-    doDownload "-" "" "jenkins" "${version}" "-" "" "" "" "jenkins.war"
-    mkdir -p "${JENKINS_HOME}"
-    doRunCommand "mv '${DEVON_DOWNLOAD_DIR}/jenkins.war' '${JENKINS_HOME}/jenkins.war'"
-    # http://localhost:9999/jnlpJars/jenkins-cli.jar
+    # shellcheck disable=SC2034
+    TOOL_VERSION_COMMAND="-"
+    doInstall "jenkins" "${JENKINS_VERSION}" "" "" "" "" "noUnpack" "" "" "jenkins.war"
     local cwd="${PWD}"
     cd "${JENKINS_HOME}" || exit 255
-    doRunCommand "jar xf jenkins.war WEB-INF/jenkins-cli.jar"
+    local version=${JENKINS_VERSION}
+    if [ -z "${JENKINS_VERSION}" ]
+    then
+      version="$(doGetLatestSoftwareVersion "jenkins")"
+    fi
+    doRunCommand "jar xf jenkins.war WEB-INF/lib/cli-${version}.jar"
+    doRunCommand "mv 'WEB-INF/lib/cli-${version}.jar' 'jenkins-cli.jar'"
+    doRunCommand "rm -rf WEB-INF/"
     cd "${cwd}" || exit 255
   fi
   if [ "${1}" != "silent" ] && ! doIsQuiet

--- a/scripts/src/main/resources/scripts/command/jenkins
+++ b/scripts/src/main/resources/scripts/command/jenkins
@@ -13,7 +13,8 @@ fi
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
 JENKINS_CLI_HOME="${DEVON_IDE_HOME}/software/jenkins"
-TOOL_VERSION_COMMAND="java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war' --version"
+JENKINS_COMMAND="java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war'"
+TOOL_VERSION_COMMAND="${JENKINS_COMMAND} --version"
 # shellcheck source=scripts/commandlet-cli
 source "$(dirname "${0}")"/../commandlet-cli
 
@@ -48,13 +49,13 @@ function doSetup() {
   fi
   if [ "${1}" != "silent" ] && ! doIsQuiet
   then
-    doRunCommand "java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war' --version" "verify installation of Jenkins"
+    doRunCommand "${JENKINS_COMMAND} --version" "verify installation of Jenkins"
   fi
 }
 
 function doStart() {
   doSetup silent
-  doRunCommand "java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war' --httpPort=${JENKINS_PORT:-9999} ${JENKINS_OPTS} || echo -e 'Jenkins could not be started.\nIf you see \"Address already in use\" error above this only means it was already running.' &"
+  doRunCommand "${JENKINS_COMMAND} --httpPort=${JENKINS_PORT:-9999} ${JENKINS_OPTS} || echo -e 'Jenkins could not be started.\nIf you see \"Address already in use\" error above this only means it was already running.' &"
   sleep 15
   echo
   echo "Jenkins is running on http://localhost:${JENKINS_PORT:-9999}"
@@ -64,10 +65,12 @@ function doJenkinsCli() {
   local admin_password="admin"
   if [ -f "${JENKINS_HOME}/secrets/initialAdminPassword" ]
   then
-    admin_password="`cat ${JENKINS_HOME}/secrets/initialAdminPassword`"
+    admin_password="$(cat "${JENKINS_HOME}"/secrets/initialAdminPassword)"
   fi
-  echo java -Duser.home=${JENKINS_HOME} -jar "${JENKINS_CLI_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}" "${@}"
-  java -Duser.home=${JENKINS_HOME} -jar "${JENKINS_CLI_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}" "${@}"
+  local jenkins_cli_command="java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins-cli.jar'"
+  echo "${jenkins_cli_command}" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}" "${@}"
+  # shellcheck disable=SC2145
+  doRunCommand "${jenkins_cli_command} -s 'http://localhost:${JENKINS_PORT:-9999}' -auth '${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}' ${@}"
 }
 
 function doStop() {

--- a/scripts/src/main/resources/scripts/command/jenkins
+++ b/scripts/src/main/resources/scripts/command/jenkins
@@ -12,26 +12,30 @@ fi
 
 # shellcheck source=scripts/functions
 source "$(dirname "${0}")"/../functions
-JENKINS_HOME="${DEVON_IDE_HOME}/software/jenkins"
-TOOL_VERSION_COMMAND="java -jar '${JENKINS_HOME}/jenkins.war' --version"
+JENKINS_CLI_HOME="${DEVON_IDE_HOME}/software/jenkins"
+TOOL_VERSION_COMMAND="java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war' --version"
 # shellcheck source=scripts/commandlet-cli
 source "$(dirname "${0}")"/../commandlet-cli
 
 # $1: optional setup
 function doSetup() {
   doDevonCommand java setup silent
-  if [ -d "${JENKINS_HOME}" ]
+  if [ -d "${JENKINS_CLI_HOME}" ]
   then
     if [ "${1}" != "silent" ]
     then
-      echo "Jenkins is already installed at ${JENKINS_HOME}"
+      echo "Jenkins is already installed at ${JENKINS_CLI_HOME}"
     fi
   else
+    if [ ! -f "${JENKINS_HOME}" ]
+    then
+      doRunCommand "mkdir '${JENKINS_HOME}'"
+    fi
     # shellcheck disable=SC2034
     TOOL_VERSION_COMMAND="-"
     doInstall "jenkins" "${JENKINS_VERSION}" "" "" "" "" "noUnpack" "" "" "jenkins.war"
     local cwd="${PWD}"
-    cd "${JENKINS_HOME}" || exit 255
+    cd "${JENKINS_CLI_HOME}" || exit 255
     local version=${JENKINS_VERSION}
     if [ -z "${JENKINS_VERSION}" ]
     then
@@ -44,21 +48,26 @@ function doSetup() {
   fi
   if [ "${1}" != "silent" ] && ! doIsQuiet
   then
-    doRunCommand "java -jar '${JENKINS_HOME}/jenkins.war' --version" "verify installation of Jenkins"
+    doRunCommand "java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war' --version" "verify installation of Jenkins"
   fi
 }
 
 function doStart() {
   doSetup silent
-  doRunCommand "java -jar '${JENKINS_HOME}/jenkins.war' --httpPort=${JENKINS_PORT:-9999} ${JENKINS_OPTS} || echo -e 'Jenkins could not be started.\nIf you see \"Address already in use\" error above this only means it was already running.' &"
-  sleep 15  
+  doRunCommand "java -Duser.home=${JENKINS_HOME} -jar '${JENKINS_CLI_HOME}/jenkins.war' --httpPort=${JENKINS_PORT:-9999} ${JENKINS_OPTS} || echo -e 'Jenkins could not be started.\nIf you see \"Address already in use\" error above this only means it was already running.' &"
+  sleep 15
   echo
   echo "Jenkins is running on http://localhost:${JENKINS_PORT:-9999}"
 }
 
 function doJenkinsCli() {
-  echo java -jar "${JENKINS_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-admin}" "${@}"
-  java -jar "${JENKINS_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-admin}" "${@}"
+  local admin_password="admin"
+  if [ -f "${JENKINS_HOME}/secrets/initialAdminPassword" ]
+  then
+    admin_password="`cat ${JENKINS_HOME}/secrets/initialAdminPassword`"
+  fi
+  echo java -Duser.home=${JENKINS_HOME} -jar "${JENKINS_CLI_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}" "${@}"
+  java -Duser.home=${JENKINS_HOME} -jar "${JENKINS_CLI_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-${admin_password}}" "${@}"
 }
 
 function doStop() {
@@ -76,7 +85,7 @@ function doAdd() {
   then
     doFail "Could not find Jenkinsfile (${JENKINSFILE})."
   fi
-  sed "s~@GIT@~file://${PWD}~" "${DEVON_IDE_HOME}/scripts/templates/jenkins/project.xml" | sed "s~@UUID@~$(head -c 20 /dev/random | base64)~" | java -jar "${JENKINS_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-admin}" create-job "$(basename "${PWD}")"
+  sed "s~@GIT@~file://${PWD}~" "${DEVON_IDE_HOME}/scripts/templates/jenkins/project.xml" | sed "s~@UUID@~$(head -c 20 /dev/random | base64)~" | java -jar "${JENKINS_CLI_HOME}/jenkins-cli.jar" -s "http://localhost:${JENKINS_PORT:-9999}" -auth "${JENKINS_ADMIN_LOGIN:-admin}:${JENKINS_ADMIN_PASSWORD:-admin}" create-job "$(basename "${PWD}")"
 }
 
 function doRemove() {

--- a/scripts/src/main/resources/scripts/devon.properties
+++ b/scripts/src/main/resources/scripts/devon.properties
@@ -18,6 +18,7 @@ export M2_REPO=${DEVON_IDE_HOME}/conf/.m2/repository
 export MAVEN_HOME=${DEVON_IDE_HOME}/software/mvn
 export MAVEN_OPTS=-Duser.home=${DEVON_IDE_HOME}/conf
 export COBIGEN_HOME=${DEVON_IDE_HOME}/conf/.cobigen
+export JENKINS_HOME=${DEVON_IDE_HOME}/conf/.jenkins
 DOCKER_EDITION=rancher
 
 # Eclipse

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1391,13 +1391,14 @@ function doInstall() {
   fi
   if [ ! -d "${install_path}" ] || [ "${install_path}" == "${target_path}" ]
   then
+    local debugMsg="Received download file ${DOWNLOAD_FILENAME}"
     if [ -z "${target_filename}" ]
     then
       doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}"
-      doDebug "Received download file ${DOWNLOAD_FILENAME}"
+      doDebug "${debugMsg}"
     else
       doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}" "${target_filename}"
-      doDebug "Received download file ${DOWNLOAD_FILENAME} with file name ${target_filename}"
+      doDebug "${debugMsg} with file name ${target_filename}"
     fi
     if [ -n "${noUnpack}" ]
     then

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1264,15 +1264,16 @@ function doResolveDownloadUrl() {
   echo "${1}"
 }
 
-# $1: name of software
-# $2: version of software
-# $3: optional silent flag ('silent' to suppress output if already up-to-date or empty for version output)
-# $4: optional edition (e.g. "enterprise" or "community")
-# $5: optional absolute target path where to install
-# $6: optional OS indicator ('-' if OS independent)
-# $7: optional to ignore extracting downloaded files (use 'noUnpack' or leave empty to extract)
-# $8: optional software repository
-# $9: optional download URL
+#  $1: name of software
+#  $2: version of software
+#  $3: optional silent flag ('silent' to suppress output if already up-to-date or empty for version output)
+#  $4: optional edition (e.g. "enterprise" or "community")
+#  $5: optional absolute target path where to install
+#  $6: optional OS indicator ('-' if OS independent)
+#  $7: optional to ignore extracting downloaded files (use 'noUnpack' or leave empty to extract)
+#  $8: optional software repository
+#  $9: optional download URL
+# $10: optional target filename
 function doInstall() {
   doDebug "doInstall ${*}"
   local software="${1}"
@@ -1284,6 +1285,7 @@ function doInstall() {
   local noUnpack="${7}"
   local repository="${8}"
   local url="${9}"
+  local target_filename="${10}"
   if [ -z "${target_path}" ]
   then
     target_path="${DEVON_IDE_HOME}/software/${software}"
@@ -1389,8 +1391,14 @@ function doInstall() {
   fi
   if [ ! -d "${install_path}" ] || [ "${install_path}" == "${target_path}" ]
   then
-    doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}"
-    doDebug "Received download file ${DOWNLOAD_FILENAME}"
+    if [ -z "${target_filename}" ]
+    then
+      doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}"
+      doDebug "Received download file ${DOWNLOAD_FILENAME}"
+    else
+      doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}" "${target_filename}"
+      doDebug "Received download file ${DOWNLOAD_FILENAME} with file name ${target_filename}"
+    fi
     if [ -n "${noUnpack}" ]
     then
       doDebug "Download shall not be extracted, hence copying ${DOWNLOAD_FILENAME} to ${install_path}"

--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1378,15 +1378,8 @@ function doInstall() {
   fi
   if [ ! -d "${install_path}" ] || [ "${install_path}" == "${target_path}" ]
   then
-    local debugMsg="Received download file ${DOWNLOAD_FILENAME}"
-    if [ -z "${target_filename}" ]
-    then
-      doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}"
-      doDebug "${debugMsg}"
-    else
-      doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}" "${target_filename}"
-      doDebug "${debugMsg} with file name ${target_filename}"
-    fi
+    doDownload "${url}" "${download_dir}" "${software}" "${version}" "${edition}" "${os}" "${arch}" "${ext}" "${target_filename}"
+    doDebug "Received download file ${DOWNLOAD_FILENAME} with file name ${target_filename}"
     if [ -n "${noUnpack}" ]
     then
       doDebug "Download shall not be extracted, hence copying ${DOWNLOAD_FILENAME} to ${install_path}"


### PR DESCRIPTION
Adresses/Fixes: #1164 

Implements:
* added new JENKINS_HOME environment variable to devon.properties
* renamed JENKINS_HOME in jenkins script to JENKINS_CLI_HOME
* added jenkins home folder creation to doSetup
* added override of java user.home to each java command of jenkins
* added first version of admin password retrieval
* added new param target_filename to doInstall
* added extra condition to doInstall to provide a filename for doDownload
* replaced doDownload in jenkins tool command with doInstall
* adjusted extraction of jenkins-cli.jar in doSetup of jenkins (jenkins-cli.jar was removed from WEB_INF folder in later jenkins versions)
* replaced password with auth file