### PR TITLE
#1132: remove obsolete dependencies

### DIFF
--- a/url-updater/pom.xml
+++ b/url-updater/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.devonfw.tools.ide.dev</groupId>
-		<artifactId>devonfw-ide</artifactId>
-		<version>dev-SNAPSHOT</version>
-	</parent>
-	<groupId>com.devonfw.tools.ide</groupId>
-	<artifactId>devonfw-ide-url-updater</artifactId>
-	<packaging>jar</packaging>
-	<version>${revision}</version>
-	<name>${project.artifactId}</name>
-	<description>Code for maintenance of download urls of IDEs tools (Eclipse, Docker, etc.).</description>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw.tools.ide.dev</groupId>
+    <artifactId>devonfw-ide</artifactId>
+    <version>dev-SNAPSHOT</version>
+  </parent>
+  <groupId>com.devonfw.tools.ide</groupId>
+  <artifactId>devonfw-ide-url-updater</artifactId>
+  <packaging>jar</packaging>
+  <version>${revision}</version>
+  <name>${project.artifactId}</name>
+  <description>Code for maintenance of download urls of IDEs tools (Eclipse, Docker, etc.).</description>
 
   <properties>
     <java.version>11</java.version>
@@ -20,21 +21,21 @@
 
   <dependencies>
     <!-- JSON and XML support -->
-		<dependency>
-			<groupId>javax.json</groupId>
-			<artifactId>javax.json-api</artifactId>
-			<version>1.1.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<version>1.1.4</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.14.1</version>
-		</dependency>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.14.1</version>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
@@ -46,26 +47,15 @@
       <version>2.14.1</version>
     </dependency>
     <!-- Logging -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>2.0.3</version>
-		</dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.3</version>
+    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.4.7</version>
-    </dependency>
-		<!-- TODO: #1132 the following dependencies should be removed -->
-    <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-java</artifactId>
-      <version>4.7.2</version>
-    </dependency>
-    <dependency>
-      <groupId>io.github.bonigarcia</groupId>
-      <artifactId>webdrivermanager</artifactId>
-      <version>4.2.2</version>
     </dependency>
     <!-- Needed for WireMock test support -->
     <dependency>
@@ -74,23 +64,23 @@
       <version>2.35.0</version>
       <scope>test</scope>
     </dependency>
-	</dependencies>
+  </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<mainClass>com.devonfw.tools.ide.url.UpdateInitiator</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>com.devonfw.tools.ide.url.UpdateInitiator</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/AbstractUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/AbstractUrlUpdater.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -33,7 +34,6 @@ import com.devonfw.tools.ide.url.model.folder.UrlTool;
 import com.devonfw.tools.ide.url.model.folder.UrlVersion;
 import com.devonfw.tools.ide.util.DateTimeUtil;
 import com.devonfw.tools.ide.util.HexUtil;
-import com.google.common.base.Objects;
 
 /**
  * Abstract base implementation of {@link UrlUpdater}. Contains methods for retrieving response bodies from URLs,
@@ -225,7 +225,7 @@ public abstract class AbstractUrlUpdater extends AbstractProcessorWithTimeout im
     UrlChecksum urlChecksum = urlVersion.getOrCreateChecksum(urlDownloadFile.getName());
     String oldChecksum = urlChecksum.getChecksum();
 
-    if ((oldChecksum != null) && !Objects.equal(oldChecksum, checksum)) {
+    if ((oldChecksum != null) && !Objects.equals(oldChecksum, checksum)) {
       logger.error("For tool {} and version {} the mirror URL {} points to a different checksum {} but expected {}.",
           tool, version, url, checksum, oldChecksum);
       return false;
@@ -411,7 +411,7 @@ public abstract class AbstractUrlUpdater extends AbstractProcessorWithTimeout im
         if (errorStatus == null) {
           modified = true;
         } else {
-          if (!Objects.equal(code, errorStatus.getCode())) {
+          if (!Objects.equals(code, errorStatus.getCode())) {
             logger.warn("For tool {} and version {} the error status-code changed from {} to {} for URL {}.", tool,
                 version, code, errorStatus.getCode(), code, url);
             modified = true;


### PR DESCRIPTION
In #1132 with PR #1205 the usage of selenium was removed from the code.
This is a cleanup PR to also remove the now obsolete maven dependencies that are not used anymore since this change.