### PR TITLE
#1283: #1276: checksum verification only for ide-urls

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -629,9 +629,6 @@ function doDownload() {
     result=${?}
     if [ "${result}" = 0 ] || [ "${result}" = 255 ]
     then
-      local checksum
-      checksum="$(cat "${DEVON_IDE_HOME}"/urls/"${software}"/"${edition}"/"${version}"/"${os}"_"${arch}".urls.sha256)"
-      doVerifyChecksums "${target_dir}"/"${filename}" "${checksum}" "${url_file}"
       return "${result}"
     fi
     doFail "Failed to download ${filename} from ${1}" "${result}"


### PR DESCRIPTION
Seems to fix both #1283 and #1276