### PR TITLE
#1330 GcViewer DonwloadUrl not Working

### DIFF
--- a/ide/src/main/java/com/devonfw/tools/ide/url/updater/gcviewer/GcViewerUrlUpdater.java
+++ b/ide/src/main/java/com/devonfw/tools/ide/url/updater/gcviewer/GcViewerUrlUpdater.java
@@ -16,7 +16,7 @@ public class GcViewerUrlUpdater extends GithubUrlUpdater {
   @Override
   protected void addVersion(UrlVersion urlVersion) {
 
-    doAddVersion(urlVersion, "https://sourceforge.net/projects/gcviewer/files/gcviewer-${version}.jar/download");
+    doAddVersion(urlVersion, "https://sourceforge.net/projects/gcviewer/files/gcviewer-${version}.jar");
   }
 
   @Override


### PR DESCRIPTION
#1330 GcViewer DonwloadUrl not Working 

The URL added in #1134 only works, when manually downloading, when using with the ide tool, it downloads meta data and not the desired .jar. Therefore the "old" url must be used, despite being one that will be redirected.
