### PR TITLE
#1367: added fix to java version compare

### DIFF
--- a/scripts/src/main/resources/scripts/functions
+++ b/scripts/src/main/resources/scripts/functions
@@ -1607,6 +1607,20 @@ function doVersionCompare() {
     then
       local p1="${v1/[^0-9]*/}"
       local p2="${v2/[^0-9]*/}"
+
+      # java versions may contain "_" indicating probably a build number
+      # let the major version be x and the build number y then the desired behaviour is x_y < x.0.1
+      if [ "${p1}" = "${p2}" ]
+      then
+        if [[ "${s1}" =~ "_" ]] && ! [[ "${s2}" =~ "_" ]]
+        then
+          return 2
+        fi
+        if [[ "${s2}" =~ "_" ]] && ! [[ "${s1}" =~ "_" ]]
+        then
+          return 1
+        fi
+      fi
       local n1="${p1}"
       local n2="${p2}"
       if [ -z "${n1}" ]

--- a/scripts/src/test/bash/test-version-compare
+++ b/scripts/src/test/bash/test-version-compare
@@ -59,5 +59,10 @@ doTestVersionCompare 3.0.0-beta17 '>' 3.0.0-beta11-SNAPSHOT
 doTestVersionCompare 3.0.0.11 '>' 3.0.0-beta11-SNAPSHOT
 doTestVersionCompare 2020.04.001 '>' 3.3.1
 doTestVersionCompare "11*" '>' "11u0"
+doTestVersionCompare 21.0.1_12 '>' 21_35
+doTestVersionCompare 21_35 '<' 21.0.1_12
+doTestVersionCompare 21_35 '<' 21
+doTestVersionCompare 21_35 '<' 21_36
+doTestVersionCompare 21_35 '<' 21_36.2
 
 exit "${exitcode}"


### PR DESCRIPTION
Fixes #1367. Added small clause to `doVersionCompare()` to make version like `21_35` smaller than `21.0.1_12`.